### PR TITLE
fix(sorters):🐛Renamed obsolete mcdoc (directory -> functions_location)

### DIFF
--- a/python_package/stewbeet/plugins/datapack/sorters/mod.mcdoc
+++ b/python_package/stewbeet/plugins/datapack/sorters/mod.mcdoc
@@ -2,7 +2,7 @@ dispatch minecraft:resource[sorter] to struct Sorter {
     /// Sorting algorithm to use: `"selection_sort"` (recommended) or `"quick_sort"`
     algorithm?: SorterAlgorithm,
     /// Namespaced function ID where sorting functions are generated
-    directory: #[id="function"] string,
+    functions_location: #[id="function"] string,
     /// Location of the list to sort
     to_sort: SorterLocation,
     /// The key to the number getting compared.


### PR DESCRIPTION
Oopsy Daisy I wrote the mcdoc with the old key