### PR TITLE
feat: add easy equations api

### DIFF
--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 	"mecha>=0.102.3",
 	"mutagen>=1.47.0",
 	"pyperclip>=1.8.0",
+	"re",
 	"smithed",
 ]
 

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
 	"mecha>=0.102.3",
 	"mutagen>=1.47.0",
 	"pyperclip>=1.8.0",
-	"re",
 	"smithed",
 ]
 

--- a/python_package/stewbeet/core/__init__.py
+++ b/python_package/stewbeet/core/__init__.py
@@ -11,8 +11,8 @@ from .cls.recipe import *
 from .cls.wiki_button import *
 from .constants import *
 from .definitions_helper import *
+from .utils.equation import *
 from .utils.io import *
 from .utils.sounds import *
 from .utils.text_component import *
-from .utils.equation import Equation
 

--- a/python_package/stewbeet/core/__init__.py
+++ b/python_package/stewbeet/core/__init__.py
@@ -14,4 +14,5 @@ from .definitions_helper import *
 from .utils.io import *
 from .utils.sounds import *
 from .utils.text_component import *
+from .utils.equation import Equation
 

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -10,7 +10,7 @@ def _is_macro_argument(value: str):
 def _get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
 	return f"scoreboard players set {player} {scoreboard} {value}"
 def _get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
-	return f"scoreboard players operation {player} {scoreboard} {operator} {value} {value_scoreboard}"
+	return f"scoreboard players operation {player} {scoreboard} {operator}= {value} {value_scoreboard}"
 def _write_constant_to_load(value: int) -> None:
 	"""
 	Writes a constant definition to the load file if it doesn't already exist.
@@ -23,6 +23,32 @@ def _write_constant_to_load(value: int) -> None:
 	constant_definition: str = _get_scoreboard_set(f"#{value}", f"{Mem.ctx.project_id}.data", value)
 	if constant_definition not in existing_load_content.splitlines():
 		write_load_file(constant_definition)
+def _get_comment_operation(operator: str, player: str|int, scoreboard: str|None) -> str:
+	"""
+	Generates a part of the comment for the current operation.
+
+	Args:
+		operator	(str):	The operator involved in the operation, like "*", "/", "+", or "-"
+		player		(str | int):	The player involved in the operation. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+		scoreboard	(str | None):	The scoreboard objective involved in the operation
+
+	Returns:
+		str: A part of the comment describing the operation.
+
+	Examples:
+		>>> _get_comment_operation("*", "@s", "some_scoreboard")
+		'* @s some_scoreboard'
+
+		>>> _get_comment_operation("+", "$(macro_arg)", None)
+		'+ $(macro_arg)'
+	"""
+	comment = []
+	if operator is not None:
+		comment.append(operator)
+	comment.append(str(player))
+	if scoreboard is not None:
+		comment.append(scoreboard)
+	return " ".join(comment)
 
 class ScoreboardEquation:
 	def __init__(self, player: str, scoreboard: str|None = None):
@@ -41,12 +67,13 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_version = "1.0.0"
 
 			>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-			'$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
+			'# scoreboard #temp_durability some_score = -$(amount) * 1000000 / $(max_damage) - #toto\\n$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		self.player = player
 		self.scoreboard = scoreboard
 		self.operations: list[str] = []
+		self.actions: list[str] = [f"{player} {scoreboard}"]
 	def __str__(self) -> str:
 		"""
 		Returns the equation as mcfunction scoreboard operations.
@@ -54,7 +81,11 @@ class ScoreboardEquation:
 		Returns:
 			str: The equation as mcfunction scoreboard operations.
 		"""
-		return "\n".join(self.operations)
+		comment = self._get_head_comment()
+		operations = "\n".join(self.operations)
+		return f"# {comment}\n{operations}"
+	def _get_head_comment(self) -> str:
+		return f"scoreboard {self.player} {self.scoreboard} = {' '.join(self.actions)}"
 
 	def __operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
 		"""
@@ -75,16 +106,16 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_id = "test"
 			>>> Mem.ctx.project_version = "1.0.0"
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/=").operations
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/").operations
 			['scoreboard players operation @s test.data /= other_player other_scoreboard']
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-=", "temp_macro").operations
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-", "temp_macro").operations
 			['$scoreboard players set #temp_macro test.data $(macro_arg)', 'scoreboard players operation @s test.data -= #temp_macro test.data']
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+=").operations
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+").operations
 			['scoreboard players operation @s test.data += #42 test.data']
 		"""
-		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
+		self.actions.append(_get_comment_operation(operator, player, scoreboard))
 		if isinstance(player, int):
 			_write_constant_to_load(player)
 			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
@@ -93,6 +124,7 @@ class ScoreboardEquation:
 			self.operations.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
 			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
 		else:
+			if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
 
@@ -107,7 +139,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self.__operation(player, scoreboard, "*=", temp_name="temp_multiply")
+		return self.__operation(player, scoreboard, "*", temp_name="temp_multiply")
 	def divide(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Divides the current scoreboard value
@@ -119,7 +151,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self.__operation(player, scoreboard, "/=", temp_name="temp_divide")
+		return self.__operation(player, scoreboard, "/", temp_name="temp_divide")
 	def add(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Adds to the current scoreboard value
@@ -131,7 +163,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self.__operation(player, scoreboard, "+=", temp_name="temp_add")
+		return self.__operation(player, scoreboard, "+", temp_name="temp_add")
 	def subtract(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Subtracts from the current scoreboard value
@@ -143,7 +175,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self.__operation(player, scoreboard, "-=", temp_name="temp_subtract")
+		return self.__operation(player, scoreboard, "-", temp_name="temp_subtract")
 	def set(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Sets the current scoreboard value
@@ -175,7 +207,8 @@ class ScoreboardEquation:
 			# it's useless to use temporary variable in this case
 			self.operations.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
-			return self.__operation(player, scoreboard, "=")
+			return self.__operation(player, scoreboard, "")
+		self.actions = [str(player)]
 		return self
 
 class StorageEquation(ScoreboardEquation):
@@ -196,15 +229,18 @@ class StorageEquation(ScoreboardEquation):
 			>>> Mem.ctx.project_version = "1.0.0"
 
 			>>> str(StorageEquation("some_namespace:some_path", "result_path", 0.000005).set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-			'$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
+			'# storage some_namespace:some_path result_path = -$(amount) * 1000000 / $(max_damage) - #toto * 0.000005\\n$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
 		"""
 		super().__init__("#temp_result")
 		self.storage = storage
 		self.path = path
 		self.scale = scale
+		self.actions: list[str] = [f"{storage} {path}"]
 	def __str__(self) -> str:
 		self.operations.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
 		return super().__str__()
+	def _get_head_comment(self) -> str:
+		return f"storage {self.storage} {self.path} = {" ".join(self.actions)} * {format(self.scale, 'f')}"
 
 # Public API
 class Equation:

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -46,7 +46,7 @@ class ScoreboardEquation:
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		self.player = player
 		self.scoreboard = scoreboard
-		self.text: list[str] = []
+		self.operations: list[str] = []
 	def __str__(self) -> str:
 		"""
 		Returns the equation as mcfunction scoreboard operations.
@@ -54,7 +54,7 @@ class ScoreboardEquation:
 		Returns:
 			str: The equation as mcfunction scoreboard operations.
 		"""
-		return "\n".join(self.text)
+		return "\n".join(self.operations)
 
 	def __operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
 		"""
@@ -75,25 +75,25 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_id = "test"
 			>>> Mem.ctx.project_version = "1.0.0"
 
-			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/="))
-			'scoreboard players operation @s test.data /= other_player other_scoreboard'
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/=").operations
+			['scoreboard players operation @s test.data /= other_player other_scoreboard']
 
-			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-=", "temp_macro"))
-			'$scoreboard players set #temp_macro test.data $(macro_arg)\\nscoreboard players operation @s test.data -= #temp_macro test.data'
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-=", "temp_macro").operations
+			['$scoreboard players set #temp_macro test.data $(macro_arg)', 'scoreboard players operation @s test.data -= #temp_macro test.data']
 
-			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+="))
-			'scoreboard players operation @s test.data += #42 test.data'
+			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+=").operations
+			['scoreboard players operation @s test.data += #42 test.data']
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		if isinstance(player, int):
 			_write_constant_to_load(player)
-			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
+			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
 		elif _is_macro_argument(player):
 			# store in temp variable
-			self.text.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
-			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
+			self.operations.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
+			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
 		else:
-			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
+			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
 
 	def multiply(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
@@ -162,18 +162,18 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_id = "test"
 			>>> Mem.ctx.project_version = "1.0.0"
 
-			>>> str(ScoreboardEquation("@s").set(42))
-			'scoreboard players set @s test.data 42'
+			>>> ScoreboardEquation("@s").set(42).operations
+			['scoreboard players set @s test.data 42']
 
-			>>> str(ScoreboardEquation("@s").set("$(macro_value)"))
-			'$scoreboard players set @s test.data $(macro_value)'
+			>>> ScoreboardEquation("@s").set("$(macro_value)").operations
+			['$scoreboard players set @s test.data $(macro_value)']
 		"""
 		if isinstance(player, int):
 			# it's useless constant value in this case
-			self.text.append(_get_scoreboard_set(self.player, self.scoreboard, player))
+			self.operations.append(_get_scoreboard_set(self.player, self.scoreboard, player))
 		elif _is_macro_argument(player):
 			# it's useless to use temporary variable in this case
-			self.text.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
+			self.operations.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
 			return self.__operation(player, scoreboard, "=")
 		return self
@@ -203,7 +203,7 @@ class StorageEquation(ScoreboardEquation):
 		self.path = path
 		self.scale = scale
 	def __str__(self) -> str:
-		self.text.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
+		self.operations.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
 		return super().__str__()
 
 # Public API

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -1,6 +1,28 @@
 
 # Imports
 from ..__memory__ import Mem
+from .io import read_function, write_load_file
+
+def __get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
+	return f"scoreboard players set {player} {scoreboard} {value}"
+def __get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
+	return f"scoreboard players operation {player} {scoreboard} {operator} {value} {value_scoreboard}"
+def __write_constant_to_load(value: int) -> None:
+	"""
+	Writes a constant definition to the load file if it doesn't already exist.
+
+	Args:
+		value (int): The constant value to write.
+
+	Example:
+		>>> write_constant_to_load(42)
+		# This will set the scoreboard #42 {project_id}:data = 42 if it isn't already defined in the load file.
+	"""
+	load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
+	existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""
+	constant_definition: str = __get_scoreboard_set(f"#{value}", f"{Mem.ctx.project_id}.data", value)
+	if constant_definition not in existing_load_content.splitlines():
+		write_load_file(constant_definition)
 
 class ScoreboardEquation:
 	def __init__(self, player: str, scoreboard: str|None = None):
@@ -24,81 +46,90 @@ class ScoreboardEquation:
 		"""
 		return "\n".join(self.text)
 
-	def _operation(self, player: str, scoreboard: str|None, operator: str) -> "ScoreboardEquation":
+	def _operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
 		"""
 		Manipulates the scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the operation. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the operation. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 			operator	(str):			The operator to use in the operation. Must be one of "*=", "/=", "+=", "-=".
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
-		self.text.append(f"scoreboard players operation {self.player} {self.scoreboard} {operator} {player} {scoreboard}")
+		if isinstance(player, int):
+			__write_constant_to_load(player)
+			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
+		else:
+			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
 
-	def multiply(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+	def multiply(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Multiplies the current scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
 		return self._operation(player, scoreboard, "*=")
-	def divide(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+	def divide(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Divides the current scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the division. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the division. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
 		return self._operation(player, scoreboard, "/=")
-	def add(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+	def add(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Adds to the current scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the addition. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the addition. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
 		return self._operation(player, scoreboard, "+=")
-	def subtract(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+	def subtract(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Subtracts from the current scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
 		return self._operation(player, scoreboard, "-=")
-	def set(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+	def set(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Sets the current scoreboard value
 
 		Args:
-			player		(str):			The player whose scoreboard value will be used in the set operation. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			player		(str | int):	The player whose scoreboard value will be used in the setting. Can be a selector, a player name, a fake player, or an integer constant.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "=")
+		if isinstance(player, int):
+			# it's useless constant value in this case
+			self.text.append(__get_scoreboard_set(self.player, self.scoreboard, player))
+		else:
+			return self._operation(player, scoreboard, "=")
+		return self
 
 

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -2,7 +2,11 @@
 # Imports
 from ..__memory__ import Mem
 from .io import read_function, write_load_file
+from re import compile
 
+macro_pattern = compile(r"\$\(\w+\)")
+def __is_macro_argument(value: str):
+	return macro_pattern.search(value) is not None
 def __get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
 	return f"scoreboard players set {player} {scoreboard} {value}"
 def __get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
@@ -51,8 +55,8 @@ class ScoreboardEquation:
 		Manipulates the scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the operation. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the operation. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 			operator	(str):			The operator to use in the operation. Must be one of "*=", "/=", "+=", "-=".
 
 		Returns:
@@ -62,6 +66,10 @@ class ScoreboardEquation:
 		if isinstance(player, int):
 			__write_constant_to_load(player)
 			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
+		elif __is_macro_argument(player):
+			# store in temp variable
+			self.text.append(f"${__get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
+			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
 		else:
 			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
@@ -71,56 +79,56 @@ class ScoreboardEquation:
 		Multiplies the current scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "*=")
+		return self._operation(player, scoreboard, "*=", temp_name="temp_multiply")
 	def divide(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Divides the current scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the division. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the division. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "/=")
+		return self._operation(player, scoreboard, "/=", temp_name="temp_divide")
 	def add(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Adds to the current scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the addition. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the addition. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "+=")
+		return self._operation(player, scoreboard, "+=", temp_name="temp_add")
 	def subtract(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Subtracts from the current scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "-=")
+		return self._operation(player, scoreboard, "-=", temp_name="temp_subtract")
 	def set(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Sets the current scoreboard value
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the setting. Can be a selector, a player name, a fake player, or an integer constant.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant.
+			player		(str | int):	The player whose scoreboard value will be used in the setting. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
@@ -128,6 +136,9 @@ class ScoreboardEquation:
 		if isinstance(player, int):
 			# it's useless constant value in this case
 			self.text.append(__get_scoreboard_set(self.player, self.scoreboard, player))
+		elif __is_macro_argument(player):
+			# it's useless to use temporary variable in this case
+			self.text.append(f"${__get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
 			return self._operation(player, scoreboard, "=")
 		return self

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -4,15 +4,6 @@ from ..__memory__ import Mem
 from .io import read_function, write_load_file
 from re import compile
 
-"""
-Setup the mocks for the tests
->>> from unittest.mock import MagicMock
->>> from stewbeet.core.__memory__ import Mem
->>> Mem.ctx = MagicMock()
->>> Mem.ctx.project_id = "test"
->>> Mem.ctx.project_version = "1.0.0"
-"""
-
 macro_pattern = compile(r"\$\(\w+\)")
 def _is_macro_argument(value: str):
 	return macro_pattern.search(value) is not None
@@ -68,6 +59,12 @@ class ScoreboardEquation:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 
 		Examples:
+			>>> from unittest.mock import MagicMock
+			>>> from stewbeet.core.__memory__ import Mem
+			>>> Mem.ctx = MagicMock()
+			>>> Mem.ctx.project_id = "test"
+			>>> Mem.ctx.project_version = "1.0.0"
+
 			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/="))
 			'scoreboard players operation @s test.data /= other_player other_scoreboard'
 
@@ -149,6 +146,12 @@ class ScoreboardEquation:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 
 		Examples:
+			>>> from unittest.mock import MagicMock
+			>>> from stewbeet.core.__memory__ import Mem
+			>>> Mem.ctx = MagicMock()
+			>>> Mem.ctx.project_id = "test"
+			>>> Mem.ctx.project_version = "1.0.0"
+
 			>>> str(ScoreboardEquation("@s").set(42))
 			'scoreboard players set @s test.data 42'
 

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -1,104 +1,108 @@
 
 # Imports
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+import stouputils as stp
+
 from ..__memory__ import Mem
-from .io import read_function, write_load_file
-from re import compile
 
-macro_pattern = compile(r"\$\(\w+\)")
-def _is_macro_argument(value: str):
-	return macro_pattern.search(value) is not None
-def _get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
+# Constants
+MACRO_RE = re.compile(r"\$\(\w+\)")
+AnyOperator = Literal["*", "/", "+", "-", "%", ""]
+
+# Helpers
+def is_macro_argument(value: str) -> bool:
+	""" Returns True if the value contains a macro argument pattern like ``$(foo)``.
+
+	>>> is_macro_argument("$(amount)")
+	True
+	>>> is_macro_argument("#toto")
+	False
+	"""
+	return bool(MACRO_RE.search(value))
+
+def get_scoreboard_set(player: str, scoreboard: str, value: str | int) -> str:
+	""" Returns a ``scoreboard players set`` command string.
+
+	>>> get_scoreboard_set("#42", "test.data", 42)
+	'scoreboard players set #42 test.data 42'
+	"""
 	return f"scoreboard players set {player} {scoreboard} {value}"
-def _get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
-	return f"scoreboard players operation {player} {scoreboard} {operator}= {value} {value_scoreboard}"
-def _write_constant_to_load(value: int) -> None:
+
+def get_scoreboard_operation(player: str, scoreboard: str, operator: AnyOperator, source: str, source_scoreboard: str) -> str:
+	""" Returns a ``scoreboard players operation`` command string.
+
+	>>> get_scoreboard_operation("@s", "test.data", "*", "#1000000", "test.data")
+	'scoreboard players operation @s test.data *= #1000000 test.data'
 	"""
-	Writes a constant definition to the load file if it doesn't already exist.
+	return f"scoreboard players operation {player} {scoreboard} {operator}= {source} {source_scoreboard}"
 
-	Args:
-		value (int): The constant value to write.
+def get_comment_token(operator: AnyOperator, player: str | int, scoreboard: str | None) -> str:
+	""" Builds one token for the equation head comment.
+
+	>>> get_comment_token("*", "@s", "some_score")
+	'* @s some_score'
+	>>> get_comment_token("+", "$(macro_arg)", None)
+	'+ $(macro_arg)'
+	>>> get_comment_token("", "#source", None)
+	'#source'
 	"""
-	load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
-	existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""
-	constant_definition: str = _get_scoreboard_set(f"#{value}", f"{Mem.ctx.project_id}.data", value)
-	if constant_definition not in existing_load_content.splitlines():
-		write_load_file(constant_definition)
-def _get_comment_operation(operator: str, player: str|int, scoreboard: str|None) -> str:
-	"""
-	Generates a part of the comment for the current operation.
-
-	Args:
-		operator	(str):	The operator involved in the operation, like "*", "/", "+", or "-"
-		player		(str | int):	The player involved in the operation. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-		scoreboard	(str | None):	The scoreboard objective involved in the operation
-
-	Returns:
-		str: A part of the comment describing the operation.
-
-	Examples:
-		>>> _get_comment_operation("*", "@s", "some_scoreboard")
-		'* @s some_scoreboard'
-
-		>>> _get_comment_operation("+", "$(macro_arg)", None)
-		'+ $(macro_arg)'
-	"""
-	comment = []
-	if operator is not None:
-		comment.append(operator)
-	comment.append(str(player))
+	parts: list[str] = []
+	if operator:
+		parts.append(operator)
+	parts.append(str(player))
 	if scoreboard is not None:
-		comment.append(scoreboard)
-	return " ".join(comment)
+		parts.append(scoreboard)
+	return " ".join(parts)
 
-class ScoreboardEquation:
-	def __init__(self, player: str, scoreboard: str|None = None):
-		"""
-		Create an equation that stores its result in a scoreboard
 
-		Args:
-			player		(str):			The player whose scoreboard will store the result. Can be a selector, a player name, or a fake player.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+# Classes
 
-		Examples:
-			>>> from unittest.mock import MagicMock
-			>>> from stewbeet.core.__memory__ import Mem
-			>>> Mem.ctx = MagicMock()
-			>>> Mem.ctx.project_id = "test"
-			>>> Mem.ctx.project_version = "1.0.0"
+class BaseEquation:
+	""" Abstract base for chainable scoreboard equation builders.
 
-			>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-			'# scoreboard #temp_durability some_score = -$(amount) * 1000000 / $(max_damage) - #toto\\n$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto some_score'
-		"""
-		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
-		self.player = player
-		self.scoreboard = scoreboard
-		self.operations: list[str] = []
-		self.actions: list[str] = [f"{player} {scoreboard}"]
+	Subclasses implement ``render_header`` and may override ``__str__``.
+	All methods return ``self`` to allow method chaining.
+	"""
+
+	def __init__(self, target_player: str, target_scoreboard: str | None = None) -> None:
+		self.player: str = target_player
+		self.scoreboard: str = target_scoreboard or f"{Mem.ctx.project_id}.data"
+		self.ops: list[str] = []
+		self.comment_parts: list[str] = [f"{target_player} {self.scoreboard}"]
+
 	def __str__(self) -> str:
-		"""
-		Returns the equation as mcfunction scoreboard operations.
+		lines = [f"# {self.render_header()}", *self.ops]
+		return "\n".join(lines)
 
-		Returns:
-			str: The equation as mcfunction scoreboard operations.
-		"""
-		comment = self._get_head_comment()
-		operations = "\n".join(self.operations)
-		return f"# {comment}\n{operations}"
-	def _get_head_comment(self) -> str:
-		return f"scoreboard {self.player} {self.scoreboard} = {' '.join(self.actions)}"
+	@stp.abstract
+	def render_header(self) -> str:
+		""" Returns the human-readable equation comment (without the leading ``# ``). """
+		...
 
-	def __operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
-		"""
-		Manipulates the scoreboard value
+	# Operation builder
+	def apply_operation(
+		self,
+		player: str | int | BaseEquation,
+		scoreboard: str | None,
+		operator: AnyOperator,
+		temp: str = "temp",
+	) -> BaseEquation:
+		""" Appends the scoreboard commands for one arithmetic operation.
+
+		Handles three cases:
+		- integer constant  -> registers it in load, uses ``#<value>`` fake player
+		- macro argument    -> stores macro value in a temp variable first
+		- player/selector   -> direct scoreboard operation
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the operation. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-			operator	(str):			The operator to use in the operation, like "*", "/", "+", or "-".
-			temp_name	(str):			The name of the temporary variable to use if needed. Defaults to "temp".
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
+			player      (str | int | BaseEquation):   Source value (selector, fake player, int constant, macro arg, or another equation).
+			scoreboard  (str | None):  Source scoreboard. Ignored for int/macro; defaults to ``self.scoreboard``.
+			operator    (AnyOperator): One of ``*``, ``/``, ``+``, ``-``, or ``""`` (for assignment via operation).
+			temp        (str):         Name of the temporary fake player used for macro args.
 
 		Examples:
 			>>> from unittest.mock import MagicMock
@@ -107,86 +111,62 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_id = "test"
 			>>> Mem.ctx.project_version = "1.0.0"
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/").operations
+			>>> # The following examples do not precise the scoreboard argument, so it defaults to {ctx.project_id}.data
+			>>> eq = BaseEquation("@s")
+			>>> eq.apply_operation("other_player", "other_scoreboard", "/").ops
 			['scoreboard players operation @s test.data /= other_player other_scoreboard']
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-", "temp_macro").operations
+			>>> eq2 = BaseEquation("@s")
+			>>> eq2.apply_operation("$(macro_arg)", None, "-", temp="temp_macro").ops
 			['$scoreboard players set #temp_macro test.data $(macro_arg)', 'scoreboard players operation @s test.data -= #temp_macro test.data']
 
-			>>> ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+").operations
+			>>> eq3 = BaseEquation("@s")
+			>>> eq3.apply_operation(42, None, "+").ops
 			['scoreboard players operation @s test.data += #42 test.data']
 		"""
-		self.actions.append(_get_comment_operation(operator, player, scoreboard))
+		# Special case with another equation as source:
+		# we need to render it first to generate the intermediate scoreboard operations,
+		# then we can use its final value as source for the next operation
+		cancel_next_comment: bool = False
+		if isinstance(player, BaseEquation):
+			# Render the other equation to generate its commands in self.ops
+			self.ops.extend(player.ops)
+			source_comment = str(player).splitlines()
+			self.comment_parts.append(f"{operator} ({source_comment[0][2:]})")	# Add the other equation header (without the leading "# ")
+			cancel_next_comment = True	# Prevent the source to add up
+
+			# The final value of the source equation is always stored in self.player and self.scoreboard of the source equation
+			scoreboard = player.scoreboard
+			player = player.player
+
+		# Update the equation comment
+		if not cancel_next_comment:
+			self.comment_parts.append(get_comment_token(operator, player, scoreboard))
+		add_op = self.ops.append
+
+		# Handle different source types
 		if isinstance(player, int):
-			_write_constant_to_load(player)
-			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
-		elif _is_macro_argument(player):
-			# store in temp variable
-			self.operations.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
-			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
+			# e.g. "scoreboard players operation @s test.data += #42 test.data"
+			add_op(get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
+		elif is_macro_argument(player):
+			# e.g. "$scoreboard players set #temp test.data $(macro_arg)""
+			add_op(f"${get_scoreboard_set(f'#{temp}', f"{Mem.ctx.project_id}.data", player)}")
+			# e.g. "scoreboard players operation @s test.data -= #temp test.data"
+			add_op(get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp}", f"{Mem.ctx.project_id}.data"))
 		else:
-			if scoreboard is None: scoreboard = self.scoreboard
-			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
+			# e.g. "scoreboard players operation @s test.data /= other_player other_scoreboard"
+			resolved: str = scoreboard or self.scoreboard
+			add_op(get_scoreboard_operation(self.player, self.scoreboard, operator, str(player), resolved))
+
 		return self
 
-	def multiply(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
-		"""
-		Multiplies the current scoreboard value
+	# Public methods for operations
+	def set(self, player: str | int, scoreboard: str | None = None) -> BaseEquation:
+		""" Sets the scoreboard value (assignment, not operation), should be used for the first operation in the chain.
 
 		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
-		"""
-		return self.__operation(player, scoreboard, "*", temp_name="temp_multiply")
-	def divide(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
-		"""
-		Divides the current scoreboard value
-
-		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the division. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
-		"""
-		return self.__operation(player, scoreboard, "/", temp_name="temp_divide")
-	def add(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
-		"""
-		Adds to the current scoreboard value
-
-		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the addition. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
-		"""
-		return self.__operation(player, scoreboard, "+", temp_name="temp_add")
-	def subtract(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
-		"""
-		Subtracts from the current scoreboard value
-
-		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
-		"""
-		return self.__operation(player, scoreboard, "-", temp_name="temp_subtract")
-	def set(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
-		"""
-		Sets the current scoreboard value
-
-		Args:
-			player		(str | int):	The player whose scoreboard value will be used in the setting. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
-			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-
-		Returns:
-			ScoreboardEquation: The current equation instance, allowing for method chaining.
+			player      (str | int):   The value to assign. Can be an int, a macro arg, or a player/selector.
+			scoreboard  (str | None):  Source scoreboard (ignored for int/macro).
 
 		Examples:
 			>>> from unittest.mock import MagicMock
@@ -195,57 +175,157 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_id = "test"
 			>>> Mem.ctx.project_version = "1.0.0"
 
-			>>> ScoreboardEquation("@s").set(42).operations
+			>>> # Setting @s in test.data to 42 and checking the generated commands with .ops
+			>>> BaseEquation("@s").set(42).ops
 			['scoreboard players set @s test.data 42']
 
-			>>> ScoreboardEquation("@s").set("$(macro_value)").operations
+			>>> # Setting @s in test.data to a macro argument and checking the generated commands with .ops
+			>>> BaseEquation("@s").set("$(macro_value)").ops
 			['$scoreboard players set @s test.data $(macro_value)']
 		"""
+		# Handle different source types for the initial set operation
 		if isinstance(player, int):
-			# it's useless constant value in this case
-			self.operations.append(_get_scoreboard_set(self.player, self.scoreboard, player))
-		elif _is_macro_argument(player):
-			# it's useless to use temporary variable in this case
-			self.operations.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
+			self.ops.append(get_scoreboard_set(self.player, self.scoreboard, player))
+		elif is_macro_argument(player):
+			self.ops.append(f"${get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
-			if scoreboard is None: scoreboard = self.scoreboard
-			self.__operation(player, scoreboard, "")
-		self.actions = [str(player) if scoreboard is None else f"{player} {scoreboard}"]
+			self.apply_operation(player, scoreboard or self.scoreboard, "")
+
+		# Reset the comment parts to only include the initial value
+		self.comment_parts = [str(player) if scoreboard is None else f"{player} {scoreboard}"]
 		return self
 
-class StorageEquation(ScoreboardEquation):
-	def __init__(self, storage: str, path: str, scale: float = 1.0):
-		"""
-		Create an equation that stores its result in a storage
+	def multiply(self, player: str | int | BaseEquation, scoreboard: str | None = None) -> BaseEquation:
+		""" Multiplies the current scoreboard value. See ``apply_operation`` for details. """
+		return self.apply_operation(player, scoreboard, "*", temp="temp_multiply")
 
-		Args:
-			storage	(str):	The storage to store the result in, in the format "namespace:path".
-			path	(str):	The path in the storage to store the result in.
-			scale	(float):	The scale to apply to the result when storing it. Defaults to 1.0.
+	def divide(self, player: str | int | BaseEquation, scoreboard: str | None = None) -> BaseEquation:
+		""" Divides the current scoreboard value. See ``apply_operation`` for details ."""
+		return self.apply_operation(player, scoreboard, "/", temp="temp_divide")
 
-		Examples:
-			>>> from unittest.mock import MagicMock
-			>>> from stewbeet.core.__memory__ import Mem
-			>>> Mem.ctx = MagicMock()
-			>>> Mem.ctx.project_id = "test"
-			>>> Mem.ctx.project_version = "1.0.0"
+	def add(self, player: str | int | BaseEquation, scoreboard: str | None = None) -> BaseEquation:
+		""" Adds to the current scoreboard value. See ``apply_operation`` for details. """
+		return self.apply_operation(player, scoreboard, "+", temp="temp_add")
 
-			>>> str(StorageEquation("some_namespace:some_path", "result_path", 0.000005).set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-			'# storage some_namespace:some_path result_path = -$(amount) * 1000000 / $(max_damage) - #toto * 0.000005\\n$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
-		"""
+	def subtract(self, player: str | int | BaseEquation, scoreboard: str | None = None) -> BaseEquation:
+		""" Subtracts from the current scoreboard value. See ``apply_operation`` for details. """
+		return self.apply_operation(player, scoreboard, "-", temp="temp_subtract")
+
+	def modulo(self, player: str | int | BaseEquation, scoreboard: str | None = None) -> BaseEquation:
+		""" Applies modulo to the current scoreboard value. See ``apply_operation`` for details. """
+		return self.apply_operation(player, scoreboard, "%", temp="temp_modulo")
+
+	# Normal Python operations
+	def __add__(self, other: str | int | BaseEquation) -> BaseEquation:
+		return self.add(other)
+	def __sub__(self, other: str | int | BaseEquation) -> BaseEquation:
+		return self.subtract(other)
+	def __mul__(self, other: str | int | BaseEquation) -> BaseEquation:
+		return self.multiply(other)
+	def __truediv__(self, other: str | int | BaseEquation) -> BaseEquation:
+		return self.divide(other)
+	def __floordiv__(self, other: str | int | BaseEquation) -> BaseEquation: # Same as true div since Minecraft scoreboard operations are all integer-based
+		return self.divide(other)
+	def __mod__(self, other: str | int | BaseEquation) -> BaseEquation:
+		return self.modulo(other)
+	def __neg__(self) -> BaseEquation:
+		return self.multiply(-1)
+
+
+# Public classes (the ones that should be used in user code)
+class ScoreboardEquation(BaseEquation):
+	""" Equation whose result is stored directly in a scoreboard objective.
+
+	Examples:
+		>>> from unittest.mock import MagicMock
+		>>> from stewbeet.core.__memory__ import Mem
+		>>> Mem.ctx = MagicMock()
+		>>> Mem.ctx.project_id = "test"
+		>>> Mem.ctx.project_version = "1.0.0"
+
+		>>> # Simple equation
+		>>> str((ScoreboardEquation("@s").set(10) + 5) * (-2) / 3 % 4 - "#toto").splitlines()[0]
+		'# scoreboard @s test.data = 10 + 5 * -2 / 3 % 4 - #toto'
+
+		>>> # Building a complex equation with method chaining and checking the generated commands with .ops
+		>>> result = str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+		>>> shorter = str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)") * 1000000 / "$(max_damage)" - "#toto")
+		>>> expected = (
+		...     "# scoreboard #temp_durability some_score = -$(amount) * 1000000 / $(max_damage) - #toto\\n"
+		...     "$scoreboard players set #temp_durability some_score -$(amount)\\n"
+		...     "scoreboard players operation #temp_durability some_score *= #1000000 test.data\\n"
+		...     "$scoreboard players set #temp_divide test.data $(max_damage)\\n"
+		...     "scoreboard players operation #temp_durability some_score /= #temp_divide test.data\\n"
+		...     "scoreboard players operation #temp_durability some_score -= #toto some_score"	# <== Note that #toto inherits the scoreboard from the equation ("some_score")
+		... )
+		>>> result == expected and shorter == expected
+		True
+
+		>>> # Combining two Equation instances
+		>>> eq4 = ScoreboardEquation("@s").set(10) * 5
+		>>> eq5 = ScoreboardEquation("#toto", "some_score").set(20) * 2
+		>>> result = str(eq4 * eq5)
+		>>> expected = (
+		...     "# scoreboard @s test.data = 10 * 5 * (scoreboard #toto some_score = 20 * 2)\\n"
+		...     "scoreboard players set @s test.data 10\\n"
+		...     "scoreboard players operation @s test.data *= #5 test.data\\n"
+		...     "scoreboard players set #toto some_score 20\\n"
+		...     "scoreboard players operation #toto some_score *= #2 test.data\\n"
+		...     "scoreboard players operation @s test.data *= #toto some_score"
+		... )
+		>>> result == expected
+		True
+	"""
+	def __init__(self, player: str, scoreboard: str | None = None) -> None:
+		super().__init__(player, scoreboard)
+
+	def render_header(self) -> str:
+		return f"scoreboard {self.player} {self.scoreboard} = {' '.join(self.comment_parts)}"
+
+
+class StorageEquation(BaseEquation):
+	""" Equation that computes via a temp scoreboard, then stores the result in a storage path.
+
+	The ``scale`` factor is applied when flushing the temp scoreboard value to storage.
+
+	Examples:
+		>>> from unittest.mock import MagicMock
+		>>> from stewbeet.core.__memory__ import Mem
+		>>> Mem.ctx = MagicMock()
+		>>> Mem.ctx.project_id = "test"
+		>>> Mem.ctx.project_version = "1.0.0"
+
+		>>> start = lambda: StorageEquation("some_namespace:some_path", "result_path", 0.000005, "double").set("-$(amount)")
+		>>> result = str(start().multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+		>>> shorter = str(start() * 1000000 / "$(max_damage)" - "#toto")
+		>>> expected = (
+		...     "# storage some_namespace:some_path result_path = -$(amount) * 1000000 / $(max_damage) - #toto * 0.000005\\n"
+		...     "$scoreboard players set #temp_result test.data -$(amount)\\n"
+		...     "scoreboard players operation #temp_result test.data *= #1000000 test.data\\n"
+		...     "$scoreboard players set #temp_divide test.data $(max_damage)\\n"
+		...     "scoreboard players operation #temp_result test.data /= #temp_divide test.data\\n"
+		...     "scoreboard players operation #temp_result test.data -= #toto test.data\\n"
+		...     "execute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data"
+		... )
+		>>> result == expected and shorter == expected
+		True
+	"""
+	def __init__(self, storage: str, path: str, scale: float = 1.0, storage_type: str = "double") -> None:
 		super().__init__("#temp_result")
-		self.storage = storage
-		self.path = path
-		self.scale = scale
-		self.actions: list[str] = [f"{storage} {path}"]
-	def __str__(self) -> str:
-		self.operations.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
-		return super().__str__()
-	def _get_head_comment(self) -> str:
-		return f"storage {self.storage} {self.path} = {" ".join(self.actions)} * {format(self.scale, 'f')}"
+		self.storage: str = storage
+		self.path: str = path
+		self.scale: float = scale
+		self.storage_type: str = storage_type
+		self.comment_parts: list[str] = [f"{storage} {path}"]
 
-# Public API
-class Equation:
-	scoreboard = ScoreboardEquation
-	storage = StorageEquation
+	def render_header(self) -> str:
+		return f"storage {self.storage} {self.path} = {' '.join(self.comment_parts)} * {self.scale:f}"
+
+	def __str__(self) -> str:
+		# Add the final command to store the result in storage after all operations
+		self.ops.append(
+			f"execute store result storage {self.storage} {self.path} {self.storage_type} {self.scale:f}"
+			f" run scoreboard players get #temp_result {f"{Mem.ctx.project_id}.data"}"
+		)
+		return super().__str__()
 

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -161,3 +161,8 @@ class StorageEquation(ScoreboardEquation):
 		self.text.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
 		return super().__str__()
 
+# Public API
+class Equation:
+	scoreboard = ScoreboardEquation
+	storage = StorageEquation
+

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -5,13 +5,13 @@ from .io import read_function, write_load_file
 from re import compile
 
 macro_pattern = compile(r"\$\(\w+\)")
-def __is_macro_argument(value: str):
+def _is_macro_argument(value: str):
 	return macro_pattern.search(value) is not None
-def __get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
+def _get_scoreboard_set(player: str, scoreboard: str, value: str|int) -> str:
 	return f"scoreboard players set {player} {scoreboard} {value}"
-def __get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
+def _get_scoreboard_operation(player: str, scoreboard: str, operator: str, value: str, value_scoreboard: str) -> str:
 	return f"scoreboard players operation {player} {scoreboard} {operator} {value} {value_scoreboard}"
-def __write_constant_to_load(value: int) -> None:
+def _write_constant_to_load(value: int) -> None:
 	"""
 	Writes a constant definition to the load file if it doesn't already exist.
 
@@ -24,7 +24,7 @@ def __write_constant_to_load(value: int) -> None:
 	"""
 	load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
 	existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""
-	constant_definition: str = __get_scoreboard_set(f"#{value}", f"{Mem.ctx.project_id}.data", value)
+	constant_definition: str = _get_scoreboard_set(f"#{value}", f"{Mem.ctx.project_id}.data", value)
 	if constant_definition not in existing_load_content.splitlines():
 		write_load_file(constant_definition)
 
@@ -50,7 +50,7 @@ class ScoreboardEquation:
 		"""
 		return "\n".join(self.text)
 
-	def _operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
+	def __operation(self, player: str|int, scoreboard: str|None, operator: str, temp_name: str = "temp") -> "ScoreboardEquation":
 		"""
 		Manipulates the scoreboard value
 
@@ -64,14 +64,14 @@ class ScoreboardEquation:
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		if isinstance(player, int):
-			__write_constant_to_load(player)
-			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
-		elif __is_macro_argument(player):
+			_write_constant_to_load(player)
+			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{player}", f"{Mem.ctx.project_id}.data"))
+		elif _is_macro_argument(player):
 			# store in temp variable
-			self.text.append(f"${__get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
-			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
+			self.text.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
+			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
 		else:
-			self.text.append(__get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
+			self.text.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
 
 	def multiply(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
@@ -85,7 +85,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "*=", temp_name="temp_multiply")
+		return self.__operation(player, scoreboard, "*=", temp_name="temp_multiply")
 	def divide(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Divides the current scoreboard value
@@ -97,7 +97,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "/=", temp_name="temp_divide")
+		return self.__operation(player, scoreboard, "/=", temp_name="temp_divide")
 	def add(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Adds to the current scoreboard value
@@ -109,7 +109,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "+=", temp_name="temp_add")
+		return self.__operation(player, scoreboard, "+=", temp_name="temp_add")
 	def subtract(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Subtracts from the current scoreboard value
@@ -121,7 +121,7 @@ class ScoreboardEquation:
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
 		"""
-		return self._operation(player, scoreboard, "-=", temp_name="temp_subtract")
+		return self.__operation(player, scoreboard, "-=", temp_name="temp_subtract")
 	def set(self, player: str|int, scoreboard: str|None = None) -> "ScoreboardEquation":
 		"""
 		Sets the current scoreboard value
@@ -135,12 +135,12 @@ class ScoreboardEquation:
 		"""
 		if isinstance(player, int):
 			# it's useless constant value in this case
-			self.text.append(__get_scoreboard_set(self.player, self.scoreboard, player))
-		elif __is_macro_argument(player):
+			self.text.append(_get_scoreboard_set(self.player, self.scoreboard, player))
+		elif _is_macro_argument(player):
 			# it's useless to use temporary variable in this case
-			self.text.append(f"${__get_scoreboard_set(self.player, self.scoreboard, player)}")
+			self.text.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
-			return self._operation(player, scoreboard, "=")
+			return self.__operation(player, scoreboard, "=")
 		return self
 
 class StorageEquation(ScoreboardEquation):

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -208,8 +208,9 @@ class ScoreboardEquation:
 			# it's useless to use temporary variable in this case
 			self.operations.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
-			return self.__operation(player, scoreboard, "")
-		self.actions = [str(player)]
+			scoreboard = f"{Mem.ctx.project_id}.data" if scoreboard is None else scoreboard
+			self.__operation(player, scoreboard, "")
+		self.actions = [str(player) if scoreboard is None else f"{player} {scoreboard}"]
 		return self
 
 class StorageEquation(ScoreboardEquation):

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -1,0 +1,104 @@
+
+# Imports
+from ..__memory__ import Mem
+
+class ScoreboardEquation:
+	def __init__(self, player: str, scoreboard: str|None = None):
+		"""
+		Create an equation that stores its result in a scoreboard
+
+		Args:
+			player		(str):			The player whose scoreboard will store the result. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+		"""
+		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
+		self.player = player
+		self.scoreboard = scoreboard
+		self.text: list[str] = []
+	def __str__(self) -> str:
+		"""
+		Returns the equation as mcfunction scoreboard operations.
+
+		Returns:
+			str: The equation as mcfunction scoreboard operations.
+		"""
+		return "\n".join(self.text)
+
+	def _operation(self, player: str, scoreboard: str|None, operator: str) -> "ScoreboardEquation":
+		"""
+		Manipulates the scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the operation. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+			operator	(str):			The operator to use in the operation. Must be one of "*=", "/=", "+=", "-=".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
+		self.text.append(f"scoreboard players operation {self.player} {self.scoreboard} {operator} {player} {scoreboard}")
+		return self
+
+	def multiply(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+		"""
+		Multiplies the current scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the multiplication. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		return self._operation(player, scoreboard, "*=")
+	def divide(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+		"""
+		Divides the current scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the division. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		return self._operation(player, scoreboard, "/=")
+	def add(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+		"""
+		Adds to the current scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the addition. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		return self._operation(player, scoreboard, "+=")
+	def subtract(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+		"""
+		Subtracts from the current scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the subtraction. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		return self._operation(player, scoreboard, "-=")
+	def set(self, player: str, scoreboard: str|None = None) -> "ScoreboardEquation":
+		"""
+		Sets the current scoreboard value
+
+		Args:
+			player		(str):			The player whose scoreboard value will be used in the set operation. Can be a selector, a player name, or a fake player.
+			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Returns:
+			ScoreboardEquation: The current equation instance, allowing for method chaining.
+		"""
+		return self._operation(player, scoreboard, "=")
+
+

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -147,6 +147,13 @@ class ScoreboardEquation:
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
+
+		Examples:
+			>>> str(ScoreboardEquation("@s").set(42))
+			'scoreboard players set @s test.data 42'
+
+			>>> str(ScoreboardEquation("@s").set("$(macro_value)"))
+			'$scoreboard players set @s test.data $(macro_value)'
 		"""
 		if isinstance(player, int):
 			# it's useless constant value in this case

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -34,14 +34,14 @@ class ScoreboardEquation:
 			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
 
 		Examples:
-		>>> from unittest.mock import MagicMock
-		>>> from stewbeet.core.__memory__ import Mem
-		>>> Mem.ctx = MagicMock()
-		>>> Mem.ctx.project_id = "test"
-		>>> Mem.ctx.project_version = "1.0.0"
+			>>> from unittest.mock import MagicMock
+			>>> from stewbeet.core.__memory__ import Mem
+			>>> Mem.ctx = MagicMock()
+			>>> Mem.ctx.project_id = "test"
+			>>> Mem.ctx.project_version = "1.0.0"
 
-		>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-		'$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
+			>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+			'$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		self.player = player
@@ -189,14 +189,14 @@ class StorageEquation(ScoreboardEquation):
 			scale	(float):	The scale to apply to the result when storing it. Defaults to 1.0.
 
 		Examples:
-		>>> from unittest.mock import MagicMock
-		>>> from stewbeet.core.__memory__ import Mem
-		>>> Mem.ctx = MagicMock()
-		>>> Mem.ctx.project_id = "test"
-		>>> Mem.ctx.project_version = "1.0.0"
+			>>> from unittest.mock import MagicMock
+			>>> from stewbeet.core.__memory__ import Mem
+			>>> Mem.ctx = MagicMock()
+			>>> Mem.ctx.project_id = "test"
+			>>> Mem.ctx.project_version = "1.0.0"
 
-		>>> str(StorageEquation("some_namespace:some_path", "result_path", 0.000005).set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-		'$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
+			>>> str(StorageEquation("some_namespace:some_path", "result_path", 0.000005).set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+			'$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
 		"""
 		super().__init__("#temp_result")
 		self.storage = storage

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -94,7 +94,8 @@ class ScoreboardEquation:
 		Args:
 			player		(str | int):	The player whose scoreboard value will be used in the operation. Can be a selector, a player name, a fake player, an integer constant, or a macro argument.
 			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data", ignored if player is an integer constant or a macro argument.
-			operator	(str):			The operator to use in the operation. Must be one of "*=", "/=", "+=", "-=".
+			operator	(str):			The operator to use in the operation, like "*", "/", "+", or "-".
+			temp_name	(str):			The name of the temporary variable to use if needed. Defaults to "temp".
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -143,4 +143,21 @@ class ScoreboardEquation:
 			return self._operation(player, scoreboard, "=")
 		return self
 
+class StorageEquation(ScoreboardEquation):
+	def __init__(self, storage: str, path: str, scale: float = 1.0):
+		"""
+		Create an equation that stores its result in a storage
+
+		Args:
+			storage	(str):	The storage to store the result in, in the format "namespace:path".
+			path	(str):	The path in the storage to store the result in.
+			scale	(float):	The scale to apply to the result when storing it. Defaults to 1.0.
+		"""
+		super().__init__("#temp_result")
+		self.storage = storage
+		self.path = path
+		self.scale = scale
+	def __str__(self) -> str:
+		self.text.append(f"execute store result storage {self.storage} {self.path} double {format(self.scale, 'f')} run scoreboard players get #temp_result {Mem.ctx.project_id}.data")
+		return super().__str__()
 

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -66,6 +66,16 @@ class ScoreboardEquation:
 
 		Returns:
 			ScoreboardEquation: The current equation instance, allowing for method chaining.
+
+		Examples:
+			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation("other_player", "other_scoreboard", "/="))
+			'scoreboard players operation @s test.data /= other_player other_scoreboard'
+
+			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation("$(macro_arg)", None, "-=", "temp_macro"))
+			'$scoreboard players set #temp_macro test.data $(macro_arg)\\nscoreboard players operation @s test.data -= #temp_macro test.data'
+
+			>>> str(ScoreboardEquation("@s")._ScoreboardEquation__operation(42, None, "+="))
+			'scoreboard players operation @s test.data += #42 test.data'
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		if isinstance(player, int):

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -67,7 +67,7 @@ class ScoreboardEquation:
 			>>> Mem.ctx.project_version = "1.0.0"
 
 			>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
-			'# scoreboard #temp_durability some_score = -$(amount) * 1000000 / $(max_damage) - #toto\\n$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
+			'# scoreboard #temp_durability some_score = -$(amount) * 1000000 / $(max_damage) - #toto\\n$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto some_score'
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		self.player = player
@@ -125,7 +125,7 @@ class ScoreboardEquation:
 			self.operations.append(f"${_get_scoreboard_set(f'#{temp_name}', f'{Mem.ctx.project_id}.data', player)}")
 			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, f"#{temp_name}", f"{Mem.ctx.project_id}.data"))
 		else:
-			if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
+			if scoreboard is None: scoreboard = self.scoreboard
 			self.operations.append(_get_scoreboard_operation(self.player, self.scoreboard, operator, player, scoreboard))
 		return self
 
@@ -208,7 +208,7 @@ class ScoreboardEquation:
 			# it's useless to use temporary variable in this case
 			self.operations.append(f"${_get_scoreboard_set(self.player, self.scoreboard, player)}")
 		else:
-			scoreboard = f"{Mem.ctx.project_id}.data" if scoreboard is None else scoreboard
+			if scoreboard is None: scoreboard = self.scoreboard
 			self.__operation(player, scoreboard, "")
 		self.actions = [str(player) if scoreboard is None else f"{player} {scoreboard}"]
 		return self

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -32,6 +32,16 @@ class ScoreboardEquation:
 		Args:
 			player		(str):			The player whose scoreboard will store the result. Can be a selector, a player name, or a fake player.
 			scoreboard	(str | None):	The scoreboard objective to use. Defaults to "{project_id}:data".
+
+		Examples:
+		>>> from unittest.mock import MagicMock
+		>>> from stewbeet.core.__memory__ import Mem
+		>>> Mem.ctx = MagicMock()
+		>>> Mem.ctx.project_id = "test"
+		>>> Mem.ctx.project_version = "1.0.0"
+
+		>>> str(ScoreboardEquation("#temp_durability", "some_score").set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+		'$scoreboard players set #temp_durability some_score -$(amount)\\nscoreboard players operation #temp_durability some_score *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_durability some_score /= #temp_divide test.data\\nscoreboard players operation #temp_durability some_score -= #toto test.data'
 		"""
 		if scoreboard is None: scoreboard = f"{Mem.ctx.project_id}.data"
 		self.player = player
@@ -177,6 +187,16 @@ class StorageEquation(ScoreboardEquation):
 			storage	(str):	The storage to store the result in, in the format "namespace:path".
 			path	(str):	The path in the storage to store the result in.
 			scale	(float):	The scale to apply to the result when storing it. Defaults to 1.0.
+
+		Examples:
+		>>> from unittest.mock import MagicMock
+		>>> from stewbeet.core.__memory__ import Mem
+		>>> Mem.ctx = MagicMock()
+		>>> Mem.ctx.project_id = "test"
+		>>> Mem.ctx.project_version = "1.0.0"
+
+		>>> str(StorageEquation("some_namespace:some_path", "result_path", 0.000005).set("-$(amount)").multiply(1000000).divide("$(max_damage)").subtract("#toto"))
+		'$scoreboard players set #temp_result test.data -$(amount)\\nscoreboard players operation #temp_result test.data *= #1000000 test.data\\n$scoreboard players set #temp_divide test.data $(max_damage)\\nscoreboard players operation #temp_result test.data /= #temp_divide test.data\\nscoreboard players operation #temp_result test.data -= #toto test.data\\nexecute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data'
 		"""
 		super().__init__("#temp_result")
 		self.storage = storage

--- a/python_package/stewbeet/core/utils/equation.py
+++ b/python_package/stewbeet/core/utils/equation.py
@@ -4,6 +4,15 @@ from ..__memory__ import Mem
 from .io import read_function, write_load_file
 from re import compile
 
+"""
+Setup the mocks for the tests
+>>> from unittest.mock import MagicMock
+>>> from stewbeet.core.__memory__ import Mem
+>>> Mem.ctx = MagicMock()
+>>> Mem.ctx.project_id = "test"
+>>> Mem.ctx.project_version = "1.0.0"
+"""
+
 macro_pattern = compile(r"\$\(\w+\)")
 def _is_macro_argument(value: str):
 	return macro_pattern.search(value) is not None
@@ -17,10 +26,6 @@ def _write_constant_to_load(value: int) -> None:
 
 	Args:
 		value (int): The constant value to write.
-
-	Example:
-		>>> write_constant_to_load(42)
-		# This will set the scoreboard #42 {project_id}:data = 42 if it isn't already defined in the load file.
 	"""
 	load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
 	existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""

--- a/python_package/stewbeet/plugins/finalyze/scoreboard_constants/__init__.py
+++ b/python_package/stewbeet/plugins/finalyze/scoreboard_constants/__init__.py
@@ -1,0 +1,49 @@
+
+# Imports
+import stouputils as stp
+from beet import Context
+
+from ....core.__memory__ import Mem
+from ....core.utils.io import write_load_file
+
+
+# Main entry point
+@stp.measure_time(message="Execution time of 'stewbeet.plugins.finalyze.scoreboard_constants'")
+def beet_default(ctx: Context):
+	""" Main entry point for the scoreboard constants plugin.
+	This plugin looks for all usage of scoreboard constants in the project and generates their set commands in the load function.
+
+	Pattern is ``#{integer} {ctx.project_id}.data``
+
+	Args:
+		ctx (Context): The beet context.
+	"""
+	if Mem.ctx is None: # pyright: ignore[reportUnnecessaryComparison]
+		Mem.ctx = ctx
+
+	# Get data from memory
+	assert ctx.meta["stewbeet"].get("source_lore", None) is not None, "Source lore is not set in the context metadata."
+	assert ctx.project_id, "Project ID is not set. Please set it in the project configuration."
+	ns: str = ctx.project_id
+
+	# Prepare regex pattern for scoreboard constants
+	import re
+	pattern = re.compile(rf"#(\d+) {re.escape(ns)}\.data")
+
+	# Loop through all functions and list all used scoreboard constants
+	constants: set[int] = set()
+	for func in ctx.data.functions.values():
+		for line in func.text.splitlines():
+			match = pattern.search(line)
+			if match:
+				constant_value = int(match.group(1))
+				constants.add(constant_value)
+
+	# Generate set commands for each constant and write to load function
+	if constants:
+		content: str = "\n".join([f"scoreboard players set #{constant} {ns}.data {constant}" for constant in sorted(constants)])
+		write_load_file(f"""
+# Set scoreboard constants for {ns}.data
+{content}
+""")
+

--- a/python_package/stewbeet/plugins/finalyze/scoreboard_constants/silent.py
+++ b/python_package/stewbeet/plugins/finalyze/scoreboard_constants/silent.py
@@ -1,0 +1,11 @@
+
+# Imports
+import stouputils as stp
+from beet import Context
+
+
+# Silent mode entry point
+def beet_default(ctx: Context) -> None:
+	from . import beet_default
+	return stp.silent(beet_default)(ctx)
+

--- a/templates/basic/beet.yml
+++ b/templates/basic/beet.yml
@@ -58,6 +58,7 @@ pipeline:
     - "stewbeet.plugins.compatibilities.neo_enchant"
     - "src.link" # User code
     - "mecha"
+    - "stewbeet.plugins.finalyze.scoreboard_constants"
     - "stewbeet.plugins.finalyze.custom_blocks_ticking"
     - "stewbeet.plugins.finalyze.basic_datapack_structure"
     - "stewbeet.plugins.finalyze.dependencies"

--- a/templates/extensive/beet.yml
+++ b/templates/extensive/beet.yml
@@ -55,6 +55,7 @@ pipeline:
     - "stewbeet.plugins.compatibilities.neo_enchant"
     - "src.link" # User code
     - "mecha"
+    - "stewbeet.plugins.finalyze.scoreboard_constants"
     - "stewbeet.plugins.finalyze.custom_blocks_ticking"
     - "stewbeet.plugins.finalyze.basic_datapack_structure"
     - "stewbeet.plugins.finalyze.dependencies"

--- a/templates/extensive/src/link.py
+++ b/templates/extensive/src/link.py
@@ -8,7 +8,7 @@ from stewbeet import *  # type: ignore
 # Main entry point (ran just before making finalyzing the build process (zip, headers, lang, ...))
 def beet_default(ctx: Context):
     ns: str = ctx.project_id
-    definitions: JsonDict = Mem.definitions
+    definitions: JsonDict = Mem.definitions # type: ignore
 
     # Generate ores in the world
     CustomOreGeneration.all_with_config(ore_configs = {
@@ -76,6 +76,11 @@ particle heart ~ ~1 ~ 0.5 0.5 0.5 0.01 1
 # This function is called every second for the custom block "steel_block"
 particle angry_villager ~ ~1 ~ 0.2 0.2 0.2 0.01 10
 """)
+
+    # Equation example
+    equation = ScoreboardEquation("#value", f"{ns}.data").set(10).add(5).multiply(2).divide(3).modulo(100)
+    equation2 = (ScoreboardEquation("#value2", f"{ns}.data").set(20) - 6 + 7) * 8 // 4 % 5
+    write_function(f"{ns}:equation/test", str(equation) + "\n" + str(equation2))
 
     pass
 


### PR DESCRIPTION
```py
Equation.storage("some_namespace:some_path", "result_path", 0.000005)
    .set("-$(amount)")
    .multiply(1000000)
    .divide("$(max_damage)")
    .subtract("#toto")
````
would return
```hs
$scoreboard players set #temp_result test.data -$(amount)
scoreboard players operation #temp_result test.data *= #1000000 test.data
$scoreboard players set #temp_divide test.data $(max_damage)
scoreboard players operation #temp_result test.data /= #temp_divide test.data
scoreboard players operation #temp_result test.data -= #toto test.data
execute store result storage some_namespace:some_path result_path double 0.000005 run scoreboard players get #temp_result test.data
```
it also automatically write to the load function
```hs
scoreboard players set #1000000 test.data 1000000
```
this is only written once no mater how many time you call `.add()`, `.subtract()` `.multiply()` or `.divide()` with this value
```py
Equation.scoreboard("@s")
    .add(42)
    .subtract(42)
    .add(42)
    .divide(12)
    .add(42)
```
only writes
```hs
scoreboard players set #42 test.data 42
scoreboard players set #12 test.data 12
```
in the load function