### PR TITLE
feat(io): add condition to all write_somethinng() functions

### DIFF
--- a/python_package/stewbeet/core/definitions_helper/completion.py
+++ b/python_package/stewbeet/core/definitions_helper/completion.py
@@ -11,7 +11,6 @@ from box import Box
 from ..__memory__ import Mem
 from ..cls.external_item import ExternalItem
 from ..cls.item import Item
-from ..utils.io import convert_to_serializable
 
 
 # Add item model component
@@ -151,7 +150,7 @@ def export_all_definitions_to_json(file_name: str, is_external: bool | JsonDict 
 	definitions_copy: dict[str, JsonDict] = {}
 	defs = is_external if isinstance(is_external, dict) else (Mem.external_definitions if is_external else Mem.definitions)
 	for item, data in defs.items():
-		definitions_copy[item] = convert_to_serializable(data)
+		definitions_copy[item] = stp.convert_to_serializable(data)
 
 		# Create a copy of the definitions without OVERRIDE_MODEL key
 		if "override_model" in definitions_copy[item]:

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -105,14 +105,7 @@ def write_function_tag(
 		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
 		condition   (Callable[[list[Any]], bool]): A function that takes the existing functions and returns whether the new functions should be written (default: always write)
 	"""
-	return write_tag(
-		path,
-		Mem.ctx.data.function_tags,
-		functions,
-		prepend,
-		max_level,
-		condition
-	)
+	return write_tag(path, Mem.ctx.data.function_tags, functions, prepend, max_level, condition)
 
 
 def read_function(path: str) -> str:
@@ -185,14 +178,7 @@ def write_versioned_function(
 		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	return write_function(
-		f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}",
-		content,
-		overwrite,
-		prepend,
-		tags,
-		condition,
-	)
+	return write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}", content, overwrite, prepend, tags, condition)
 
 
 def write_load_file(
@@ -211,14 +197,7 @@ def write_load_file(
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	return write_versioned_function(
-		"load/confirm_load",
-		content,
-		overwrite,
-		prepend,
-		tags,
-		condition,
-	)
+	return write_versioned_function("load/confirm_load", content, overwrite, prepend, tags, condition)
 
 
 def write_tick_file(
@@ -237,14 +216,7 @@ def write_tick_file(
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	return write_versioned_function(
-		"tick",
-		content,
-		overwrite,
-		prepend,
-		tags,
-		condition,
-	)
+	return write_versioned_function("tick", content, overwrite, prepend, tags, condition)
 
 
 def write_scheduled_function(
@@ -287,19 +259,10 @@ def write_scheduled_function(
 		body: str = f"# Wait for {schedule_delay}\n{schedule_command}"
 		if content_stripped:
 			body = f"{body}\n\n{content_stripped}"
-		write_load_file(
-			f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
-			overwrite=True,
-			prepend=prepend,
-		)
+		write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=True, prepend=prepend)
 		return write_function(path=resolved_path, content=body, overwrite=True, prepend=prepend)
 
-	write_load_file(
-		f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
-		overwrite=False,
-		prepend=prepend,
-		condition=lambda existing: schedule_command not in existing,
-	)
+	write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=False, prepend=prepend, condition=lambda existing: schedule_command not in existing)
 
 	# Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
 	if schedule_command not in existing_scheduled_content:

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -99,7 +99,7 @@ def write_function(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] = lambda existing_content: True,
+	condition: Callable[[str], bool] | None = None,
 ) -> None:
 	""" Write the content to the function at the given path.
 
@@ -115,8 +115,9 @@ def write_function(
 		path = path[:-len(".mcfunction")]
 
 	# Check condition with existing content
-	existing_content: str = Mem.ctx.data.functions[path].text if path in Mem.ctx.data.functions else ""
-	if not condition(existing_content): return
+	if condition is not None:
+		existing_content: str = read_function(path)
+		if not condition(existing_content): return
 
 	if overwrite:
 		Mem.ctx.data.functions[path] = Function(content)
@@ -136,7 +137,7 @@ def write_versioned_function(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] = lambda existing_content: True,
+	condition: Callable[[str], bool] | None = None,
 ) -> None:
 	""" Write the content to a versioned function at the given path.
 
@@ -163,7 +164,7 @@ def write_load_file(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] = lambda existing_content: True,
+	condition: Callable[[str], bool] | None = None,
 ) -> None:
 	""" Write the content to the load file
 
@@ -189,7 +190,7 @@ def write_tick_file(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] = lambda existing_content: True,
+	condition: Callable[[str], bool] | None = None,
 ) -> None:
 	""" Write the content to the tick file
 

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -212,7 +212,7 @@ def write_load_file(
 		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	return write_versioned_function(
-		"/load/confirm_load",
+		"load/confirm_load",
 		content,
 		overwrite,
 		prepend,

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -117,30 +117,6 @@ def write_function(path: str, content: str, overwrite: bool = False, prepend: bo
 			write_function_tag(tag, [path], prepend)
 
 
-def write_load_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
-	""" Write the content to the load file
-
-	Args:
-		content     (str):  The content to write
-		overwrite   (bool): If the file should be overwritten (default: Append the content)
-		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-	"""
-	write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load", content, overwrite, prepend, tags)
-
-
-def write_tick_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
-	""" Write the content to the tick file
-
-	Args:
-		content     (str):  The content to write
-		overwrite   (bool): If the file should be overwritten (default: Append the content)
-		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-	"""
-	write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/tick", content, overwrite, prepend, tags)
-
-
 def write_versioned_function(path: str, content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
 	""" Write the content to a versioned function at the given path.
 
@@ -152,6 +128,30 @@ def write_versioned_function(path: str, content: str, overwrite: bool = False, p
 		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 	"""
 	write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}", content, overwrite, prepend, tags)
+
+
+def write_load_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+	""" Write the content to the load file
+
+	Args:
+		content     (str):  The content to write
+		overwrite   (bool): If the file should be overwritten (default: Append the content)
+		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
+		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+	"""
+	write_versioned_function("load/confirm_load", content, overwrite, prepend, tags)
+
+
+def write_tick_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+	""" Write the content to the tick file
+
+	Args:
+		content     (str):  The content to write
+		overwrite   (bool): If the file should be overwritten (default: Append the content)
+		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
+		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+	"""
+	write_versioned_function("tick", content, overwrite, prepend, tags)
 
 
 def write_scheduled_function(

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -19,7 +19,7 @@ def write_advancement(
 	overwrite: bool = False,
 	max_level: int = -1,
 	condition: Callable[[JsonDict], bool] = lambda existing_data: True,
-) -> None:
+) -> Advancement | None:
 	""" Write an advancement at the given path.
 
 	Args:
@@ -48,6 +48,8 @@ def write_advancement(
 		merged_data: JsonDict = super_merge_dict(existing_data, new_data)
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(merged_data), max_level=max_level)
 
+	return Mem.ctx.data.advancements[path]
+
 # Functions
 def write_tag(
 	path: str,
@@ -56,7 +58,7 @@ def write_tag(
 	prepend: bool = False,
 	max_level: int | None = None,
 	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
-) -> None:
+) -> TagFile | None:
 	""" Write a function tag at the given path.
 
 	Args:
@@ -88,6 +90,7 @@ def write_tag(
 		tag.encoder = stp.json_dump
 	else:
 		tag.encoder = lambda x: stp.json_dump(x, max_level=max_level)
+	return tag
 
 def write_function_tag(
 	path: str,
@@ -95,7 +98,7 @@ def write_function_tag(
 	prepend: bool = False,
 	max_level: int | None = None,
 	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
-) -> None:
+) -> TagFile | None:
 	""" Write a function tag at the given path.
 
 	Args:
@@ -129,7 +132,7 @@ def write_function(
 	prepend: bool = False,
 	tags: list[str] | None = None,
 	condition: Callable[[str], bool] | None = None,
-) -> None:
+) -> Function | None:
 	""" Write the content to the function at the given path.
 
 	Args:
@@ -158,6 +161,7 @@ def write_function(
 	if tags:
 		for tag in tags:
 			write_function_tag(tag, [path], prepend)
+	return Mem.ctx.data.functions[path]
 
 
 def write_versioned_function(
@@ -167,7 +171,7 @@ def write_versioned_function(
 	prepend: bool = False,
 	tags: list[str] | None = None,
 	condition: Callable[[str], bool] | None = None,
-) -> None:
+) -> Function | None:
 	""" Write the content to a versioned function at the given path.
 
 	Args:
@@ -187,7 +191,7 @@ def write_load_file(
 	prepend: bool = False,
 	tags: list[str] | None = None,
 	condition: Callable[[str], bool] | None = None,
-) -> None:
+) -> Function | None:
 	""" Write the content to the load file
 
 	Args:
@@ -206,7 +210,7 @@ def write_tick_file(
 	prepend: bool = False,
 	tags: list[str] | None = None,
 	condition: Callable[[str], bool] | None = None,
-) -> None:
+) -> Function | None:
 	""" Write the content to the tick file
 
 	Args:
@@ -227,7 +231,7 @@ def write_scheduled_function(
 	overwrite: bool = False,
 	prepend: bool = False,
 	condition: Callable[[str], bool] = lambda existing_content: True,
-) -> None:
+) -> Function | None:
 	""" Write a self-rescheduling function and schedule it on load.
 
 	Args:
@@ -265,13 +269,13 @@ def write_scheduled_function(
 	write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=False, prepend=prepend, condition=lambda existing: schedule_command not in existing)
 
 	# Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
-	if schedule_command not in existing_scheduled_content:
-		body = f"# Wait for {schedule_delay}\n{schedule_command}"
-		if content_stripped:
-			body = f"{body}\n\n{content_stripped}"
-		return write_function(path=resolved_path, content=body, overwrite=False, prepend=prepend)
-	elif content_stripped and content_stripped not in existing_scheduled_content:
-		return write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend)
+	body = f"# Wait for {schedule_delay}\n{schedule_command}"
+	if content_stripped:
+		body = f"{body}\n\n{content_stripped}"
+	schedule = write_function(path=resolved_path, content=body, overwrite=False, prepend=prepend, condition=lambda existing: schedule_command not in existing)
+	if schedule is None and content_stripped:
+		return write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend, condition=lambda existing: content_stripped not in existing)
+	return schedule
 
 
 # Merge two dict recuirsively

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -33,8 +33,7 @@ def write_advancement(
 		path = path[:-len(".json")]
 
 	# Get existing advancement or create empty one
-	existing: Advancement = Mem.ctx.data.advancements.setdefault(path)
-	existing_data: JsonDict = existing.data
+	existing_data: JsonDict = Mem.ctx.data.advancements.get(path, {"data":{}}).data
 	# Check condition with existing data
 	if not condition(existing_data): return
 
@@ -44,6 +43,9 @@ def write_advancement(
 	if overwrite:
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(new_data), max_level=max_level)
 	else:
+		# Get existing advancement or create empty one
+		existing: Advancement = Mem.ctx.data.advancements.setdefault(path)
+		existing_data: JsonDict = existing.data
 		# Merge the new data with existing data
 		merged_data: JsonDict = super_merge_dict(existing_data, new_data)
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(merged_data), max_level=max_level)

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -109,18 +109,6 @@ def write_tag(
 	return tag
 
 
-@stp.deprecated(message="write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead", version="v3.1.3")
-def write_function_tag(
-	path: str,
-	functions: list[Any] | None = None,
-	prepend: bool = False,
-	max_level: int | None = None,
-	condition: Callable[[list[Any]], bool] = lambda existing_values: True, # pyright: ignore[reportUnknownLambdaType]
-) -> TagFile | None:
-	""" write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead """
-	return write_tag(path, Mem.ctx.data.function_tags, functions, prepend, max_level, condition)
-
-
 def read_function(path: str) -> str:
 	""" Read the content of a function at the given path.
 
@@ -176,7 +164,7 @@ def write_function(
 	# Add the function to the specified tags
 	if tags:
 		for tag in tags:
-			write_function_tag(tag, [path], prepend)
+			write_tag(tag, Mem.ctx.data.function_tags, [path], prepend)
 
 	# Return the written function
 	return func
@@ -359,29 +347,6 @@ def set_json_encoder[JsonFileT: JsonFile](
 		obj.encoder = lambda x: stp.json_dump(x, max_level=max_level, indent=indent)
 	return obj
 
-
-# Convert objects with to_dict() to JSON-serializable forms
-def convert_to_serializable(obj: Any) -> Any:
-	""" Recursively convert objects to JSON-serializable forms.
-
-	Objects with a `to_dict()` method are converted to their dictionary representation.
-	Dictionaries and lists are recursively processed.
-
-	Args:
-		obj (Any): The object to convert
-	Returns:
-		Any: The JSON-serializable version of the object
-	"""
-	if hasattr(obj, 'to_dict'):
-		return obj.to_dict()
-	elif isinstance(obj, dict):
-		return {k: convert_to_serializable(v) for k, v in obj.items()} # type: ignore
-	elif isinstance(obj, list):
-		return [convert_to_serializable(item) for item in obj] # type: ignore
-	else:
-		return obj
-
-
 # Create a texture object with mcmeta if found
 def texture_mcmeta(source_path: str) -> Texture:
 	""" Create a Texture object with mcmeta if found
@@ -395,4 +360,23 @@ def texture_mcmeta(source_path: str) -> Texture:
 	if os.path.exists(mcmeta_path):
 		return Texture(source_path=source_path, mcmeta=stp.json_load(mcmeta_path))
 	return Texture(source_path=source_path)
+
+
+
+# Deprecated functions
+@stp.deprecated(message="convert_to_serializable is deprecated, prefer using stp.convert_to_serializable from stouputils", version="v3.1.3")
+def convert_to_serializable(obj: Any) -> Any:
+	return stp.convert_to_serializable(obj)
+
+
+@stp.deprecated(message="write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead", version="v3.1.3")
+def write_function_tag(
+	path: str,
+	functions: list[Any] | None = None,
+	prepend: bool = False,
+	max_level: int | None = None,
+	condition: Callable[[list[Any]], bool] = lambda existing_values: True, # pyright: ignore[reportUnknownLambdaType]
+) -> TagFile | None:
+	""" write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead """
+	return write_tag(path, Mem.ctx.data.function_tags, functions, prepend, max_level, condition)
 

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -40,7 +40,14 @@ def write_advancement(path: str, advancement: Advancement | JsonDict, overwrite:
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(merged_data), max_level=max_level)
 
 # Functions
-def write_tag(path: str, tag_type: NamespaceProxy[Any] | NamespaceContainer[Any], values: list[Any] | None = None, prepend: bool = False, max_level: int | None = None) -> None:
+def write_tag(
+	path: str,
+	tag_type: NamespaceProxy[Any] | NamespaceContainer[Any],
+	values: list[Any] | None = None,
+	prepend: bool = False,
+	max_level: int | None = None,
+	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
+) -> None:
 	""" Write a function tag at the given path.
 
 	Args:
@@ -49,12 +56,18 @@ def write_tag(path: str, tag_type: NamespaceProxy[Any] | NamespaceContainer[Any]
 		values      (list[Any] | None): The values to add to the tag
 		prepend     (bool): If the values should be prepended instead of appended
 		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
+		condition   (Callable[[list[Any]], bool]): A function that takes the existing values and returns whether the new values should be written (default: always write)
 	"""
 	if path.endswith(".json"):
 		path = path[:-len(".json")]
 	tag: TagFile = tag_type.setdefault(path)
 	data: JsonDict = tag.data
-	if not data.get("values"):
+
+	# Check condition with existing values
+	existing_values: list[Any] = data.get("values")
+	if not condition([] if existing_values is None else existing_values): return
+
+	if not existing_values:
 		data["values"] = values or []
 
 	if prepend:
@@ -67,7 +80,13 @@ def write_tag(path: str, tag_type: NamespaceProxy[Any] | NamespaceContainer[Any]
 	else:
 		tag.encoder = lambda x: stp.json_dump(x, max_level=max_level)
 
-def write_function_tag(path: str, functions: list[Any] | None = None, prepend: bool = False, max_level: int | None = None) -> None:
+def write_function_tag(
+	path: str,
+	functions: list[Any] | None = None,
+	prepend: bool = False,
+	max_level: int | None = None,
+	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
+) -> None:
 	""" Write a function tag at the given path.
 
 	Args:
@@ -75,8 +94,16 @@ def write_function_tag(path: str, functions: list[Any] | None = None, prepend: b
 		functions   (list[Any] | None): The functions to add to the tag
 		prepend     (bool): If the functions should be prepended instead of appended
 		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
+		condition   (Callable[[list[Any]], bool]): A function that takes the existing functions and returns whether the new functions should be written (default: always write)
 	"""
-	write_tag(path, Mem.ctx.data.function_tags, functions, prepend, max_level)
+	write_tag(
+		path,
+		Mem.ctx.data.function_tags,
+		functions,
+		prepend,
+		max_level,
+		condition
+	)
 
 
 def read_function(path: str) -> str:

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -1,7 +1,8 @@
 
 # Imports
 import os
-from typing import Any, TypeVar, cast, Callable
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
 import stouputils as stp
 from beet import Advancement, Function, JsonFile, NamespaceContainer, NamespaceProxy, TagFile, Texture
@@ -18,39 +19,40 @@ def write_advancement(
 	advancement: Advancement | JsonDict,
 	overwrite: bool = False,
 	max_level: int = -1,
-	condition: Callable[[JsonDict], bool] = lambda existing_data: True,
+	condition: Callable[[JsonDict], bool] = lambda existing_data: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Advancement | None:
 	""" Write an advancement at the given path.
 
 	Args:
-		path        (str):  The path to the advancement (ex: "namespace:folder/advancement_name")
-		advancement (Advancement | JsonDict): The advancement to write
-		overwrite   (bool): If the file should be overwritten (default: Merge with existing content using super_merge_dict)
-		max_level   (int):  The maximum level of the JSON dump, -1 for default behavior (default: -1)
-		condition   (Callable[[JsonDict], bool]): A function that takes the existing advancement data and returns whether the new advancement should be written (default: always write)
+		path        (str):                         The path to the advancement (ex: "namespace:folder/advancement_name")
+		advancement (Advancement | JsonDict):      The advancement to write
+		overwrite   (bool):                        If the file should be overwritten (default: Merge with existing content using super_merge_dict)
+		max_level   (int):                         The maximum level of the JSON dump, -1 for default behavior (default: -1)
+		condition   (Callable[[JsonDict], bool]):  A function that takes the existing advancement data
+			and returns whether the new advancement should be written (default: always write)
+	Returns:
+		Advancement | None: The written advancement, or None if the condition was not met
 	"""
-	if path.endswith(".json"):
-		path = path[:-len(".json")]
+	path = path.removesuffix(".json")  # Remove .json extension if present
 
-	# Get existing advancement or create empty one
-	existing_data: JsonDict = Mem.ctx.data.advancements.get(path, {"data":{}}).data
-	# Check condition with existing data
-	if not condition(existing_data): return
+	# Get existing advancement or create empty one, and check condition with its data
+	existing_data: JsonDict = Mem.ctx.data.advancements.get(path, Advancement()).data
+	if not condition(existing_data):
+		return None
 
 	# Convert to dict if it's an Advancement object
 	new_data: JsonDict = advancement.data if isinstance(advancement, Advancement) else advancement
 
-	if overwrite:
-		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(new_data), max_level=max_level)
+	if overwrite or not existing_data:
+		adv: Advancement = set_json_encoder(Advancement(new_data), max_level=max_level)
 	else:
-		# Get existing advancement or create empty one
-		existing: Advancement = Mem.ctx.data.advancements.setdefault(path)
-		existing_data: JsonDict = existing.data
 		# Merge the new data with existing data
 		merged_data: JsonDict = super_merge_dict(existing_data, new_data)
-		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(merged_data), max_level=max_level)
+		adv: Advancement = set_json_encoder(Advancement(merged_data), max_level=max_level)
 
-	return Mem.ctx.data.advancements[path]
+	# Write the advancement to memory and return it
+	Mem.ctx.data.advancements[path] = adv
+	return adv
 
 # Functions
 def write_tag(
@@ -59,57 +61,63 @@ def write_tag(
 	values: list[Any] | None = None,
 	prepend: bool = False,
 	max_level: int | None = None,
-	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
+	condition: Callable[[list[Any]], bool] = lambda existing_values: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> TagFile | None:
 	""" Write a function tag at the given path.
 
 	Args:
-		path        (str):  The path to the function tag (ex: "namespace:something" for 'data/namespace/tags/function/something.json')
-		tag_type    (NamespaceProxy[TagFile]): The tag type to write to (ex: ctx.data.function_tags)
-		values      (list[Any] | None): The values to add to the tag
-		prepend     (bool): If the values should be prepended instead of appended
-		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
-		condition   (Callable[[list[Any]], bool]): A function that takes the existing values and returns whether the new values should be written (default: always write)
+		path        (str):                          The path to the function tag (ex: "namespace:something" for 'data/namespace/tags/function/something.json')
+		tag_type    (NamespaceProxy[TagFile]):      The tag type to write to (ex: ctx.data.function_tags)
+		values      (list[Any] | None):             The values to add to the tag
+		prepend     (bool):                         If the values should be prepended instead of appended
+		max_level   (int | None):                   The maximum level of the JSON dump, None for default behavior (default: None)
+		condition   (Callable[[list[Any]], bool]):  A function that takes the existing values and returns whether the new values should be written (default: always write)
+	Returns:
+		TagFile | None: The written tag, or None if the condition was not met
 	"""
-	if path.endswith(".json"):
-		path = path[:-len(".json")]
-	tag: TagFile = tag_type.setdefault(path)
+	path = path.removesuffix(".json")  # Remove .json extension if present
+	tag: TagFile = tag_type.get(path, TagFile())
 	data: JsonDict = tag.data
 
 	# Check condition with existing values
-	existing_values: list[Any] = data.get("values")
-	if not condition([] if existing_values is None else existing_values): return
+	existing_values: list[Any] = data.get("values", [])
+	if not condition(existing_values):
+		return None
 
+	# Set empty list if there is no existing values
 	if not existing_values:
-		data["values"] = values or []
+		data["values"] = cast(list[Any], [])
 
+	# Prepend = (new values) + (existing values)
+	# Append = (existing values) + (new values)
 	if prepend:
 		data["values"] = (values or []) + data["values"]
 	else:
 		data["values"].extend(values or [])
+
+	# Remove duplicates while preserving order
 	data["values"] = stp.unique_list(data["values"])
+
+	# Set encoder to json_dump with max_level if specified, else default behavior
 	if max_level is None:
 		tag.encoder = stp.json_dump
 	else:
 		tag.encoder = lambda x: stp.json_dump(x, max_level=max_level)
+
+	# Write the tag to memory and return it
+	tag_type[path] = tag
 	return tag
 
+
+@stp.deprecated(message="write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead", version="v3.1.3")
 def write_function_tag(
 	path: str,
 	functions: list[Any] | None = None,
 	prepend: bool = False,
 	max_level: int | None = None,
-	condition: Callable[[list[Any]], bool] = lambda existing_values: True,
+	condition: Callable[[list[Any]], bool] = lambda existing_values: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> TagFile | None:
-	""" Write a function tag at the given path.
-
-	Args:
-		path        (str):  The path to the function tag (ex: "namespace:something" for 'data/namespace/tags/function/something.json')
-		functions   (list[Any] | None): The functions to add to the tag
-		prepend     (bool): If the functions should be prepended instead of appended
-		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
-		condition   (Callable[[list[Any]], bool]): A function that takes the existing functions and returns whether the new functions should be written (default: always write)
-	"""
+	""" write_function_tag is deprecated, prefer using write_tag or `tags` argument of write_function instead """
 	return write_tag(path, Mem.ctx.data.function_tags, functions, prepend, max_level, condition)
 
 
@@ -118,13 +126,11 @@ def read_function(path: str) -> str:
 
 	Args:
 		path (str): The path to the function (ex: "namespace:folder/function_name")
-
 	Returns:
 		str: The content of the function, or an empty string if the function does not exist
 	"""
-	if path.endswith(".mcfunction"):
-		path = path[:-len(".mcfunction")]
-	return Mem.ctx.data.functions[path].text if path in Mem.ctx.data.functions else ""
+	path = path.removesuffix(".mcfunction")  # Remove .mcfunction extension if present
+	return Mem.ctx.data.functions.get(path, Function()).text
 
 
 def write_function(
@@ -133,37 +139,47 @@ def write_function(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] | None = None,
+	condition: Callable[[str], bool] | None = lambda existing_content: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Function | None:
 	""" Write the content to the function at the given path.
 
 	Args:
-		path            (str):  The path to the function (ex: "namespace:folder/function_name")
-		content         (str):  The content to write
-		overwrite       (bool): If the file should be overwritten (default: Append the content)
-		prepend         (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
+		path            (str):                    The path to the function (ex: "namespace:folder/function_name")
+		content         (str):                    The content to write
+		overwrite       (bool):                   If the file should be overwritten (default: Append the content)
+		prepend         (bool):                   If the content should be prepended instead of appended (not used if overwrite is True)
+		tags            (list[str] | None):       The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition       (Callable[[str], bool]):  A function that takes the existing content and returns whether the new content should be written (default: always write)
+	Returns:
+		Function | None: The written function, or None if the condition was not met
 	"""
-	if path.endswith(".mcfunction"):
-		path = path[:-len(".mcfunction")]
+	path = path.removesuffix(".mcfunction")
 
 	# Check condition with existing content
 	if condition is not None:
 		existing_content: str = read_function(path)
-		if not condition(existing_content): return
+		if not condition(existing_content):
+			return None
 
+	# Overwrite, prepend, or append content to the function
 	if overwrite:
-		Mem.ctx.data.functions[path] = Function(content)
+		func = Function(content)
+		Mem.ctx.data.functions[path] = func
 	else:
 		if prepend:
-			Mem.ctx.data.functions.setdefault(path).prepend(content)
+			func = Mem.ctx.data.functions.setdefault(path, Function())
+			func.prepend(content)
 		else:
-			Mem.ctx.data.functions.setdefault(path).append(content)
+			func = Mem.ctx.data.functions.setdefault(path, Function())
+			func.append(content)
+
+	# Add the function to the specified tags
 	if tags:
 		for tag in tags:
 			write_function_tag(tag, [path], prepend)
-	return Mem.ctx.data.functions[path]
+
+	# Return the written function
+	return func
 
 
 def write_versioned_function(
@@ -172,17 +188,17 @@ def write_versioned_function(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] | None = None,
+	condition: Callable[[str], bool] | None = lambda existing_content: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Function | None:
 	""" Write the content to a versioned function at the given path.
 
 	Args:
-		path            (str):  The path to the function (ex: "folder/function_name")
-		content         (str):  The content to write
-		overwrite       (bool): If the file should be overwritten (default: Append the content)
-		prepend         (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
+		path            (str):                    The path to the function (ex: "folder/function_name")
+		content         (str):                    The content to write
+		overwrite       (bool):                   If the file should be overwritten (default: Append the content)
+		prepend         (bool):                   If the content should be prepended instead of appended (not used if overwrite is True)
+		tags            (list[str] | None):       The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition       (Callable[[str], bool]):  A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	return write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}", content, overwrite, prepend, tags, condition)
 
@@ -192,16 +208,16 @@ def write_load_file(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] | None = None,
+	condition: Callable[[str], bool] | None = lambda existing_content: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Function | None:
 	""" Write the content to the load file
 
 	Args:
-		content     (str):  The content to write
-		overwrite   (bool): If the file should be overwritten (default: Append the content)
-		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
+		content     (str):                    The content to write
+		overwrite   (bool):                   If the file should be overwritten (default: Append the content)
+		prepend     (bool):                   If the content should be prepended instead of appended (not used if overwrite is True)
+		tags        (list[str] | None):       The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition   (Callable[[str], bool]):  A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	return write_versioned_function("load/confirm_load", content, overwrite, prepend, tags, condition)
 
@@ -211,16 +227,16 @@ def write_tick_file(
 	overwrite: bool = False,
 	prepend: bool = False,
 	tags: list[str] | None = None,
-	condition: Callable[[str], bool] | None = None,
+	condition: Callable[[str], bool] | None = lambda existing_content: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Function | None:
 	""" Write the content to the tick file
 
 	Args:
-		content     (str):  The content to write
-		overwrite   (bool): If the file should be overwritten (default: Append the content)
-		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
-		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
-		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
+		content     (str):                    The content to write
+		overwrite   (bool):                   If the file should be overwritten (default: Append the content)
+		prepend     (bool):                   If the content should be prepended instead of appended (not used if overwrite is True)
+		tags        (list[str] | None):       The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition   (Callable[[str], bool]):  A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	return write_versioned_function("tick", content, overwrite, prepend, tags, condition)
 
@@ -232,17 +248,17 @@ def write_scheduled_function(
 	path: str | None = None,
 	overwrite: bool = False,
 	prepend: bool = False,
-	condition: Callable[[str], bool] = lambda existing_content: True,
+	condition: Callable[[str], bool] = lambda existing_content: True, # pyright: ignore[reportUnknownLambdaType]
 ) -> Function | None:
 	""" Write a self-rescheduling function and schedule it on load.
 
 	Args:
-		duration	(int | str):	Delay before re-execution. If it's a digit-only string, it is converted to int.
-		content		(str):			Function content to execute.
-		unit		(str):			Time unit used only when duration is int (default: "t").
-		path		(str | None):	Target function path. Defaults to "{project_id}:scheduled/{duration}".
-		overwrite	(bool):			If True, overwrite target files instead of appending.
-		prepend		(bool):			If True, prepend content instead of appending (ignored when overwrite is True).
+		duration	(int | str):	         Delay before re-execution. If it's a digit-only string, it is converted to int.
+		content		(str):			         Function content to execute.
+		unit		(str):			         Time unit used only when duration is int (default: "t").
+		path		(str | None):	         Target function path. Defaults to "{project_id}:v{project_version}/scheduled/{duration}".
+		overwrite	(bool):			         If True, overwrite target files instead of appending.
+		prepend		(bool):			         If True, prepend content instead of appending (ignored when overwrite is True).
 		condition	(Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	# Normalize duration: keep custom string delays (e.g. "5s"), coerce numeric strings to int.
@@ -252,37 +268,46 @@ def write_scheduled_function(
 
 	# Build schedule command and target paths.
 	schedule_delay: str = f"{parsed_duration}{unit}" if isinstance(parsed_duration, int) else parsed_duration
-	resolved_path: str = path or f"{Mem.ctx.project_id}:scheduled/{schedule_delay}"
+	resolved_path: str = path or f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/scheduled/{schedule_delay}"
 	schedule_command: str = f"schedule function {resolved_path} {schedule_delay}"
 	content_stripped: str = content.strip("\n")
 
-	# Read existing contents for condition check and idempotent writes
-	existing_scheduled_content: str = read_function(resolved_path) if resolved_path in Mem.ctx.data.functions else ""
-	if not condition(existing_scheduled_content): return
+	# 0. Read existing contents for condition check and idempotent writes
+	existing_scheduled_content: str = read_function(resolved_path)
+	if not condition(existing_scheduled_content):
+		return
 
-	# Overwrite mode always refreshes both scheduled function and load registration.
-	if overwrite:
-		body: str = f"# Wait for {schedule_delay}\n{schedule_command}"
-		if content_stripped:
-			body = f"{body}\n\n{content_stripped}"
-		write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=True, prepend=prepend)
-		return write_function(path=resolved_path, content=body, overwrite=True, prepend=prepend)
+	# 1. Ensure the schedule command is in the load file while avoiding duplicates.
+	def is_schedule_missing(existing: str) -> bool: return (schedule_command not in existing)
+	write_load_file(
+		f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
+		overwrite=False, prepend=prepend, condition=is_schedule_missing
+	)
 
-	write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=False, prepend=prepend, condition=lambda existing: schedule_command not in existing)
-
-	# Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
-	body = f"# Wait for {schedule_delay}\n{schedule_command}"
+	# 2. Build function body: schedule self-rescheduling header + optional content
+	body_with_reschedule: str = f"# Wait for {schedule_delay}\n{schedule_command}"
 	if content_stripped:
-		body = f"{body}\n\n{content_stripped}"
-	schedule = write_function(path=resolved_path, content=body, overwrite=False, prepend=prepend, condition=lambda existing: schedule_command not in existing)
-	if schedule is None and content_stripped:
-		return write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend, condition=lambda existing: content_stripped not in existing)
-	return schedule
+		body_with_reschedule = f"{body_with_reschedule}\n\n{content_stripped}"
+
+	# 3.1. Overwrite mode always refreshes scheduled function, but not load registration
+	if overwrite:
+		write_load_file(f"# Schedule function for {schedule_delay}\n{schedule_command} replace", overwrite=True, prepend=prepend)
+		return write_function(path=resolved_path, content=body_with_reschedule, overwrite=True, prepend=prepend)
+
+	# 3.2. Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
+	func = write_function(path=resolved_path, content=body_with_reschedule, overwrite=False, prepend=prepend, condition=is_schedule_missing)
+	if func is None and content_stripped:
+		def is_content_missing(existing: str) -> bool: return (content_stripped not in existing)
+		return write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend, condition=is_content_missing)
+
+	# Return the function object
+	return func
 
 
 # Merge two dict recuirsively
 def super_merge_dict(dict1: JsonDict, dict2: JsonDict) -> JsonDict:
 	""" Merge the two dictionnaries recursively without modifying originals
+
 	Args:
 		dict1 (dict): The first dictionnary
 		dict2 (dict): The second dictionnary

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -86,11 +86,11 @@ def read_function(path: str) -> str:
 		path (str): The path to the function (ex: "namespace:folder/function_name")
 
 	Returns:
-		str: The content of the function
+		str: The content of the function, or an empty string if the function does not exist
 	"""
 	if path.endswith(".mcfunction"):
 		path = path[:-len(".mcfunction")]
-	return Mem.ctx.data.functions[path].text
+	return Mem.ctx.data.functions[path].text if path in Mem.ctx.data.functions else ""
 
 
 def write_function(

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -13,7 +13,13 @@ from ..__memory__ import Mem
 JsonFileT = TypeVar("JsonFileT", bound=JsonFile)
 
 # Advancements
-def write_advancement(path: str, advancement: Advancement | JsonDict, overwrite: bool = False, max_level: int = -1) -> None:
+def write_advancement(
+	path: str,
+	advancement: Advancement | JsonDict,
+	overwrite: bool = False,
+	max_level: int = -1,
+	condition: Callable[[JsonDict], bool] = lambda existing_data: True,
+) -> None:
 	""" Write an advancement at the given path.
 
 	Args:
@@ -21,9 +27,16 @@ def write_advancement(path: str, advancement: Advancement | JsonDict, overwrite:
 		advancement (Advancement | JsonDict): The advancement to write
 		overwrite   (bool): If the file should be overwritten (default: Merge with existing content using super_merge_dict)
 		max_level   (int):  The maximum level of the JSON dump, -1 for default behavior (default: -1)
+		condition   (Callable[[JsonDict], bool]): A function that takes the existing advancement data and returns whether the new advancement should be written (default: always write)
 	"""
 	if path.endswith(".json"):
 		path = path[:-len(".json")]
+
+	# Get existing advancement or create empty one
+	existing: Advancement = Mem.ctx.data.advancements.setdefault(path)
+	existing_data: JsonDict = existing.data
+	# Check condition with existing data
+	if not condition(existing_data): return
 
 	# Convert to dict if it's an Advancement object
 	new_data: JsonDict = advancement.data if isinstance(advancement, Advancement) else advancement
@@ -31,10 +44,6 @@ def write_advancement(path: str, advancement: Advancement | JsonDict, overwrite:
 	if overwrite:
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(new_data), max_level=max_level)
 	else:
-		# Get existing advancement or create empty one
-		existing: Advancement = Mem.ctx.data.advancements.setdefault(path)
-		existing_data: JsonDict = existing.data
-
 		# Merge the new data with existing data
 		merged_data: JsonDict = super_merge_dict(existing_data, new_data)
 		Mem.ctx.data.advancements[path] = set_json_encoder(Advancement(merged_data), max_level=max_level)

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -105,7 +105,7 @@ def write_function_tag(
 		max_level   (int | None):  The maximum level of the JSON dump, None for default behavior (default: None)
 		condition   (Callable[[list[Any]], bool]): A function that takes the existing functions and returns whether the new functions should be written (default: always write)
 	"""
-	write_tag(
+	return write_tag(
 		path,
 		Mem.ctx.data.function_tags,
 		functions,
@@ -185,7 +185,7 @@ def write_versioned_function(
 		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_function(
+	return write_function(
 		f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}",
 		content,
 		overwrite,
@@ -211,7 +211,7 @@ def write_load_file(
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_versioned_function(
+	return write_versioned_function(
 		"/load/confirm_load",
 		content,
 		overwrite,
@@ -237,7 +237,7 @@ def write_tick_file(
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
 		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_versioned_function(
+	return write_versioned_function(
 		"tick",
 		content,
 		overwrite,
@@ -287,22 +287,12 @@ def write_scheduled_function(
 		body: str = f"# Wait for {schedule_delay}\n{schedule_command}"
 		if content_stripped:
 			body = f"{body}\n\n{content_stripped}"
-		write_function(path=resolved_path, content=body, overwrite=True, prepend=prepend)
 		write_load_file(
 			f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
 			overwrite=True,
 			prepend=prepend,
 		)
-		return
-
-	# Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
-	if schedule_command not in existing_scheduled_content:
-		body = f"# Wait for {schedule_delay}\n{schedule_command}"
-		if content_stripped:
-			body = f"{body}\n\n{content_stripped}"
-		write_function(path=resolved_path, content=body, overwrite=False, prepend=prepend)
-	elif content_stripped and content_stripped not in existing_scheduled_content:
-		write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend)
+		return write_function(path=resolved_path, content=body, overwrite=True, prepend=prepend)
 
 	write_load_file(
 		f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
@@ -310,6 +300,15 @@ def write_scheduled_function(
 		prepend=prepend,
 		condition=lambda existing: schedule_command not in existing,
 	)
+
+	# Append/prepend mode: avoid duplicating schedule lines and duplicate content blocks.
+	if schedule_command not in existing_scheduled_content:
+		body = f"# Wait for {schedule_delay}\n{schedule_command}"
+		if content_stripped:
+			body = f"{body}\n\n{content_stripped}"
+		return write_function(path=resolved_path, content=body, overwrite=False, prepend=prepend)
+	elif content_stripped and content_stripped not in existing_scheduled_content:
+		return write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend)
 
 
 # Merge two dict recuirsively

--- a/python_package/stewbeet/core/utils/io.py
+++ b/python_package/stewbeet/core/utils/io.py
@@ -1,7 +1,7 @@
 
 # Imports
 import os
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, cast, Callable
 
 import stouputils as stp
 from beet import Advancement, Function, JsonFile, NamespaceContainer, NamespaceProxy, TagFile, Texture
@@ -93,7 +93,14 @@ def read_function(path: str) -> str:
 	return Mem.ctx.data.functions[path].text
 
 
-def write_function(path: str, content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+def write_function(
+	path: str,
+	content: str,
+	overwrite: bool = False,
+	prepend: bool = False,
+	tags: list[str] | None = None,
+	condition: Callable[[str], bool] = lambda existing_content: True,
+) -> None:
 	""" Write the content to the function at the given path.
 
 	Args:
@@ -102,9 +109,15 @@ def write_function(path: str, content: str, overwrite: bool = False, prepend: bo
 		overwrite       (bool): If the file should be overwritten (default: Append the content)
 		prepend         (bool): If the content should be prepended instead of appended (not used if overwrite is True)
 		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	if path.endswith(".mcfunction"):
 		path = path[:-len(".mcfunction")]
+
+	# Check condition with existing content
+	existing_content: str = Mem.ctx.data.functions[path].text if path in Mem.ctx.data.functions else ""
+	if not condition(existing_content): return
+
 	if overwrite:
 		Mem.ctx.data.functions[path] = Function(content)
 	else:
@@ -117,7 +130,14 @@ def write_function(path: str, content: str, overwrite: bool = False, prepend: bo
 			write_function_tag(tag, [path], prepend)
 
 
-def write_versioned_function(path: str, content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+def write_versioned_function(
+	path: str,
+	content: str,
+	overwrite: bool = False,
+	prepend: bool = False,
+	tags: list[str] | None = None,
+	condition: Callable[[str], bool] = lambda existing_content: True,
+) -> None:
 	""" Write the content to a versioned function at the given path.
 
 	Args:
@@ -126,11 +146,25 @@ def write_versioned_function(path: str, content: str, overwrite: bool = False, p
 		overwrite       (bool): If the file should be overwritten (default: Append the content)
 		prepend         (bool): If the content should be prepended instead of appended (not used if overwrite is True)
 		tags            (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition       (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_function(f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}", content, overwrite, prepend, tags)
+	write_function(
+		f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/{path}",
+		content,
+		overwrite,
+		prepend,
+		tags,
+		condition,
+	)
 
 
-def write_load_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+def write_load_file(
+	content: str,
+	overwrite: bool = False,
+	prepend: bool = False,
+	tags: list[str] | None = None,
+	condition: Callable[[str], bool] = lambda existing_content: True,
+) -> None:
 	""" Write the content to the load file
 
 	Args:
@@ -138,11 +172,25 @@ def write_load_file(content: str, overwrite: bool = False, prepend: bool = False
 		overwrite   (bool): If the file should be overwritten (default: Append the content)
 		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_versioned_function("load/confirm_load", content, overwrite, prepend, tags)
+	write_versioned_function(
+		"/load/confirm_load",
+		content,
+		overwrite,
+		prepend,
+		tags,
+		condition,
+	)
 
 
-def write_tick_file(content: str, overwrite: bool = False, prepend: bool = False, tags: list[str] | None = None) -> None:
+def write_tick_file(
+	content: str,
+	overwrite: bool = False,
+	prepend: bool = False,
+	tags: list[str] | None = None,
+	condition: Callable[[str], bool] = lambda existing_content: True,
+) -> None:
 	""" Write the content to the tick file
 
 	Args:
@@ -150,8 +198,16 @@ def write_tick_file(content: str, overwrite: bool = False, prepend: bool = False
 		overwrite   (bool): If the file should be overwritten (default: Append the content)
 		prepend     (bool): If the content should be prepended instead of appended (not used if overwrite is True)
 		tags        (list[str] | None): The function tags to add to the function (ex: ["namespace:something"] for 'data/namespace/tags/function/something.json')
+		condition   (Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
-	write_versioned_function("tick", content, overwrite, prepend, tags)
+	write_versioned_function(
+		"tick",
+		content,
+		overwrite,
+		prepend,
+		tags,
+		condition,
+	)
 
 
 def write_scheduled_function(
@@ -161,6 +217,7 @@ def write_scheduled_function(
 	path: str | None = None,
 	overwrite: bool = False,
 	prepend: bool = False,
+	condition: Callable[[str], bool] = lambda existing_content: True,
 ) -> None:
 	""" Write a self-rescheduling function and schedule it on load.
 
@@ -171,6 +228,7 @@ def write_scheduled_function(
 		path		(str | None):	Target function path. Defaults to "{project_id}:scheduled/{duration}".
 		overwrite	(bool):			If True, overwrite target files instead of appending.
 		prepend		(bool):			If True, prepend content instead of appending (ignored when overwrite is True).
+		condition	(Callable[[str], bool]): A function that takes the existing content and returns whether the new content should be written (default: always write)
 	"""
 	# Normalize duration: keep custom string delays (e.g. "5s"), coerce numeric strings to int.
 	parsed_duration: int | str = duration.strip() if isinstance(duration, str) else duration
@@ -183,10 +241,9 @@ def write_scheduled_function(
 	schedule_command: str = f"schedule function {resolved_path} {schedule_delay}"
 	content_stripped: str = content.strip("\n")
 
-	# Read existing contents for idempotent writes.
+	# Read existing contents for condition check and idempotent writes
 	existing_scheduled_content: str = read_function(resolved_path) if resolved_path in Mem.ctx.data.functions else ""
-	load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
-	existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""
+	if not condition(existing_scheduled_content): return
 
 	# Overwrite mode always refreshes both scheduled function and load registration.
 	if overwrite:
@@ -210,12 +267,12 @@ def write_scheduled_function(
 	elif content_stripped and content_stripped not in existing_scheduled_content:
 		write_function(path=resolved_path, content=content_stripped, overwrite=False, prepend=prepend)
 
-	if schedule_command not in existing_load_content:
-		write_load_file(
-			f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
-			overwrite=False,
-			prepend=prepend,
-		)
+	write_load_file(
+		f"# Schedule function for {schedule_delay}\n{schedule_command} replace",
+		overwrite=False,
+		prepend=prepend,
+		condition=lambda existing: schedule_command not in existing,
+	)
 
 
 # Merge two dict recuirsively

--- a/python_package/stewbeet/plugins/datapack/custom_blocks/__init__.py
+++ b/python_package/stewbeet/plugins/datapack/custom_blocks/__init__.py
@@ -22,7 +22,7 @@ from ....core.constants import (
 	VANILLA_BLOCK,
 	official_lib_used,
 )
-from ....core.utils.io import set_json_encoder, write_function, write_function_tag, write_load_file, write_versioned_function
+from ....core.utils.io import set_json_encoder, write_function, write_load_file, write_tag, write_versioned_function
 
 
 # Main entry point
@@ -430,7 +430,7 @@ scoreboard objectives add {ns}.growth_stage dummy
 			stp.debug("Found custom blocks using CUSTOM_BLOCK_VANILLA in the definitions, adding 'smithed.custom_block' to the dependencies")
 
 		# Write function tag to link with the library
-		write_function_tag("smithed.custom_block:event/on_place", [f"{ns}:custom_blocks/on_place"])
+		write_tag("smithed.custom_block:event/on_place", ctx.data.function_tags, [f"{ns}:custom_blocks/on_place"])
 
 		# Write the slot function
 		write_function(f"{ns}:custom_blocks/on_place", (

--- a/python_package/stewbeet/plugins/datapack/loading/__init__.py
+++ b/python_package/stewbeet/plugins/datapack/loading/__init__.py
@@ -7,7 +7,7 @@ from beet.core.utils import JsonDict
 
 from ....core.__memory__ import Mem
 from ....core.cls.item import Item
-from ....core.utils.io import write_function_tag, write_load_file, write_versioned_function
+from ....core.utils.io import write_load_file, write_tag, write_versioned_function
 
 
 # Main entry point
@@ -52,8 +52,8 @@ execute if score #{ctx.project_id}.major load.status matches {major} if score #{
 """)
 
 	# Setup enumerate and resolve function tags
-	write_function_tag(f"{ctx.project_id}:enumerate", [f"{ctx.project_id}:v{ctx.project_version}/load/enumerate"])
-	write_function_tag(f"{ctx.project_id}:resolve", [f"{ctx.project_id}:v{ctx.project_version}/load/resolve"])
+	write_tag(f"{ctx.project_id}:enumerate", ctx.data.function_tags, [f"{ctx.project_id}:v{ctx.project_version}/load/enumerate"])
+	write_tag(f"{ctx.project_id}:resolve", ctx.data.function_tags, [f"{ctx.project_id}:v{ctx.project_version}/load/resolve"])
 
 	# Setup load main function
 	write_versioned_function("load/main",

--- a/python_package/stewbeet/plugins/finalyze/dependencies/__init__.py
+++ b/python_package/stewbeet/plugins/finalyze/dependencies/__init__.py
@@ -6,7 +6,7 @@ from beet.core.utils import JsonDict
 
 from ....core.__memory__ import Mem
 from ....core.constants import BOOKSHELF_MODULES, LATEST_MC_VERSION, MORE_DATA_VERSIONS, OFFICIAL_LIBS, official_lib_used
-from ....core.utils.io import write_function, write_function_tag, write_versioned_function
+from ....core.utils.io import write_function, write_tag, write_versioned_function
 
 
 # Utility functions
@@ -97,9 +97,9 @@ def beet_default(ctx: Context) -> None:
 	if load_dependencies:
 		dependencies += list(load_dependencies.items())
 	# Setup Lantern Load
-	write_function_tag("minecraft:load", ["#load:_private/load"])
-	write_function_tag("load:_private/init", ["load:_private/init"])
-	write_function_tag("load:_private/load", [
+	write_tag("minecraft:load", ctx.data.function_tags, ["#load:_private/load"])
+	write_tag("load:_private/init", ctx.data.function_tags, ["load:_private/init"])
+	write_tag("load:_private/load", ctx.data.function_tags, [
 		"#load:_private/init",
 		{"id": "#load:pre_load", "required": False},
 		{"id": "#load:load", "required": False},
@@ -113,12 +113,12 @@ scoreboard players reset * load.status
 """, overwrite=True)
 
 	# Setup load json files
-	write_function_tag("load:load", [f"#{ns}:load"])
+	write_tag("load:load", ctx.data.function_tags, [f"#{ns}:load"])
 	values: list[str | JsonDict] = [f"#{ns}:enumerate", f"#{ns}:resolve"]
 	if dependencies:
-		write_function_tag(f"{ns}:enumerate", [f"#{ns}:dependencies"], prepend=True)
+		write_tag(f"{ns}:enumerate", ctx.data.function_tags, [f"#{ns}:dependencies"], prepend=True)
 
-	write_function_tag(f"{ns}:load", values)
+	write_tag(f"{ns}:load", ctx.data.function_tags, values)
 
 	if dependencies:
 		calls: list[JsonDict] = [
@@ -134,7 +134,7 @@ scoreboard players reset * load.status
 				seen.add(call_id)
 				unique_calls.append(call)
 
-		write_function_tag(f"{ns}:dependencies", unique_calls)
+		write_tag(f"{ns}:dependencies", ctx.data.function_tags, unique_calls)
 
 	# Write secondary function
 	authors: list[str] = author.replace(",", " ").replace("  ", " ").split(" ")
@@ -162,7 +162,7 @@ function {ns}:v{version}/load/confirm_load
 	# Tick verification
 	tick_path: str = f"{ns}:v{version}/tick"
 	if tick_path in ctx.data.functions:
-		write_function_tag("minecraft:tick", [f"{ns}:v{version}/load/tick_verification"])
+		write_tag("minecraft:tick", ctx.data.function_tags, ["#load/tick_verification"])
 		write_versioned_function("load/tick_verification", f"""
 execute if score #{ns}.major load.status matches {major} if score #{ns}.minor load.status matches {minor} if score #{ns}.patch load.status matches {patch} run function {ns}:v{version}/tick
 """)
@@ -172,7 +172,7 @@ execute if score #{ns}.major load.status matches {major} if score #{ns}.minor lo
 		for function_tag in ["denied_dimensions", "generate_ores", "post_generation"]:
 			function_path: str = f"{ns}:calls/smart_ore_generation/{function_tag}"
 			if function_path in ctx.data.functions:
-				write_function_tag(f"smart_ore_generation:v1/signals/{function_tag}", [function_path])
+				write_tag(f"smart_ore_generation:v1/signals/{function_tag}", ctx.data.function_tags, [function_path])
 
 	# For each used library, show message
 	used_libs: list[str] = [data["name"] for data in OFFICIAL_LIBS.values() if data["is_used"]]

--- a/python_package/stewbeet/plugins/ingame_manual/main.py
+++ b/python_package/stewbeet/plugins/ingame_manual/main.py
@@ -38,7 +38,7 @@ from ...core.constants import (
 	WIKI_COMPONENT,
 )
 from ...core.definitions_helper import add_item_name_and_lore_if_missing
-from ...core.utils.io import convert_to_serializable, super_merge_dict, write_load_file
+from ...core.utils.io import super_merge_dict, write_load_file
 from ...core.utils.text_component import item_id_to_name
 from ..custom_recipes.vanilla import VanillaRecipeHandler
 from ..initialize.source_lore_font import find_pack_png
@@ -109,7 +109,7 @@ from .stardust_forge import get_stardust_forge_page
 # Utility functions
 def deepcopy(x: Any) -> Any:
 	""" Deep copy using JSON serialization, converting WikiButton objects. """
-	return json.loads(json.dumps(convert_to_serializable(x)))
+	return json.loads(json.dumps(stp.convert_to_serializable(x)))
 
 def manual_main():
 	# Copy everything in the manual assets folder to the templates folder

--- a/python_package/stewbeet/plugins/verify_definitions/__init__.py
+++ b/python_package/stewbeet/plugins/verify_definitions/__init__.py
@@ -23,7 +23,6 @@ from ...core.constants import (
 	USED_FOR_CRAFTING,
 	VANILLA_BLOCK,
 )
-from ...core.utils.io import convert_to_serializable
 
 
 # Main entry point
@@ -46,7 +45,7 @@ def beet_default(ctx: Context) -> None:
 	definitions_copy: dict[str, JsonDict] = {}
 	for item, data in Mem.definitions.items():
 		# Convert Item objects or dicts with nested Recipe objects to fully serializable dicts
-		definitions_copy[item] = convert_to_serializable(data)
+		definitions_copy[item] = stp.convert_to_serializable(data)
 		if "override_model" in definitions_copy[item]:
 			del definitions_copy[item]["override_model"]
 


### PR DESCRIPTION
add a condition argument so that instead of doing
```py
load_path: str = f"{Mem.ctx.project_id}:v{Mem.ctx.project_version}/load/confirm_load"
existing_load_content: str = read_function(load_path) if load_path in Mem.ctx.data.functions else ""
if some_test(existing_load_content): write_load_function(some_content)
```
you can now write
```py
write_load_function(some_content, confition=lambda existing_load_content: some_test(existing_load_content))
```

I also refactored a bit:
- `write_load_function` and `write_tick_function` now call `write_versioned_function` instead of re-implementing it with `write_function`
- functions like `write_versioned_function` now don't return `None` because they return `None`, they instead return `None` because that'a what their parent (here `write_function`) returned
  - if at some point you add a return type to `write_function` it will also return it through it's children functions
  - if at some point you add a return type to `write_function` it will show errors of missmatching retrun type on the children, forcing you to think about what it should return on every branch